### PR TITLE
add kafka init topics script

### DIFF
--- a/infra/kafka/init-topics.sh
+++ b/infra/kafka/init-topics.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+KAFKA_HOST="kafka:29092"
+
+topics=(
+  "order.created"
+  "order.status_changed"
+  "order.cancelled"
+  "payment.events"
+  "payment.success"
+  "tracking.events"
+  "notification.events"
+  "shipper.assigned"
+  "order.created.DLQ"
+  "payment.events.DLQ"
+  "tracking.events.DLQ"
+)
+
+for topic in "${topics[@]}"; do
+  kafka-topics --bootstrap-server $KAFKA_HOST \
+    --create --if-not-exists \
+    --topic "$topic" \
+    --partitions 3 \
+    --replication-factor 1
+  echo "✓ Created: $topic"
+done
+
+echo "All topics created!"


### PR DESCRIPTION
## Changes
- Add init-topics.sh to create all Kafka topics on startup
- Topics: order, payment, tracking, notification, shipper events
- Include DLQ topics for failed messages
- Auto-run when kafka container is healthy