### PR TITLE
Feat/tv4/ci add frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [develop]
 
 jobs:
-  ci:
-    name: Build & Test — ${{ matrix.service }}
+  ci-backend:
+    name: Build — ${{ matrix.service }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -36,6 +36,39 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Build & Test
+      - name: Build
         working-directory: services/${{ matrix.service }}
-        run: mvn clean verify -B
+        run: mvn clean package -B -DskipTests
+
+  ci-frontend:
+    name: Build — ${{ matrix.app }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - sender-web
+          - admin-web
+          - ops-dashboard
+          - shipper-portal
+          - driver-portal
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/${{ matrix.app }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: apps/${{ matrix.app }}
+        run: npm ci
+
+      - name: Build
+        working-directory: apps/${{ matrix.app }}
+        run: npm run build

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-dev}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpass}
     ports:
-      - "5432:5432"
+      - "5436:5432"
     volumes:
       - pgdata-identity:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Changes
- Split CI into 2 jobs: ci-backend and ci-frontend
- Backend: build 9 Spring Boot services with DskipTests
- Frontend: build 5 Next.js apps (sender-web, admin-web, ops-dashboard, shipper-portal, driver-portal)
- Both jobs run in parallel using matrix strategy