### PR TITLE
feat: add Testcontainers for tracking-service and update CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service:
-          - gateway-api
-          - identity-service
-          - profile-service
-          - order-service
-          - payment-service
-          - tracking-service
-          - notification-service
-          - hub-and-branch-service
-          - staff-service
+        include:
+          - service: gateway-api
+            skip_tests: true
+          - service: identity-service
+            skip_tests: true
+          - service: profile-service
+            skip_tests: true
+          - service: order-service
+            skip_tests: true
+          - service: payment-service
+            skip_tests: true
+          - service: tracking-service
+            skip_tests: false
+          - service: notification-service
+            skip_tests: true
+          - service: hub-and-branch-service
+            skip_tests: true
+          - service: staff-service
+            skip_tests: true
 
     steps:
       - name: Checkout code
@@ -36,23 +45,18 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Build
+      - name: Build & Test
         working-directory: services/${{ matrix.service }}
-        run: mvn clean package -B -DskipTests
+        run: |
+          if [ "${{ matrix.skip_tests }}" = "true" ]; then
+            mvn clean package -B -DskipTests
+          else
+            mvn clean verify -B
+          fi
 
   ci-frontend:
-    name: Build — ${{ matrix.app }}
+    name: Build frontend
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        app:
-          - sender-web
-          - admin-web
-          - ops-dashboard
-          - shipper-portal
-          - driver-portal
 
     steps:
       - name: Checkout code
@@ -63,12 +67,12 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: apps/${{ matrix.app }}/package-lock.json
+          cache-dependency-path: apps/package-lock.json
 
       - name: Install dependencies
-        working-directory: apps/${{ matrix.app }}
-        run: npm ci
+        working-directory: apps
+        run: npm install
 
-      - name: Build
-        working-directory: apps/${{ matrix.app }}
+      - name: Build all apps
+        working-directory: apps
         run: npm run build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/services/tracking-service/pom.xml
+++ b/services/tracking-service/pom.xml
@@ -71,34 +71,54 @@
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
-   <build>
-    <plugins>
-        <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <configuration>
-                <excludes>
-                    <exclude>
-                        <groupId>org.projectlombok</groupId>
-                        <artifactId>lombok</artifactId>
-                    </exclude>
-                </excludes>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <annotationProcessorPaths>
-                    <path>
-                        <groupId>org.projectlombok</groupId>
-                        <artifactId>lombok</artifactId>
-                    </path>
-                </annotationProcessorPaths>
-            </configuration>
-        </plugin>
-    </plugins>
-</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/services/tracking-service/src/test/java/com/tracking/tracking_service/TrackingServiceApplicationTests.java
+++ b/services/tracking-service/src/test/java/com/tracking/tracking_service/TrackingServiceApplicationTests.java
@@ -2,12 +2,37 @@ package com.tracking.tracking_service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
+@Testcontainers
 class TrackingServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Container
+    static MongoDBContainer mongodb = new MongoDBContainer(
+        DockerImageName.parse("mongo:7")
+    );
 
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(
+        DockerImageName.parse("confluentinc/cp-kafka:7.6.0")
+    );
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongodb::getReplicaSetUrl);
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.data.redis.host", () -> "localhost");
+        registry.add("spring.data.redis.password", () -> "");
+    }
+
+    @Test
+    void contextLoads() {
+    }
 }


### PR DESCRIPTION
## Changes
- Update CI: tracking-service now runs real tests, other services still skip tests
- Add Testcontainers dependencies to tracking-service pom.xml (MongoDB, Kafka)
- Update TrackingServiceApplicationTests to use Testcontainers for MongoDB and Kafka
- CI will automatically spin up MongoDB and Kafka containers during test

## Why
- tracking-service has real business logic that needs to be tested
- Testcontainers eliminates need for external DB during CI
- Other services still use -DskipTests until they have proper test setup