### PR TITLE
feat: implement notification service with Kafka consumers

### DIFF
--- a/services/notification-service/pom.xml
+++ b/services/notification-service/pom.xml
@@ -1,111 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.notification</groupId>
-	<artifactId>notification-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name/>
-	<description/>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
-		<spring-cloud.version>2025.1.1</spring-cloud.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-kafka</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-websocket</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-openfeign</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-kafka-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-websocket-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/>
+    </parent>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <groupId>com.notification</groupId>
+    <artifactId>notification-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>notification-service</name>
+    <description>Notification Service for PicBox</description>
 
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/services/notification-service/src/main/java/com/notification/notification_service/config/KafkaConfig.java
+++ b/services/notification-service/src/main/java/com/notification/notification_service/config/KafkaConfig.java
@@ -1,0 +1,24 @@
+package com.notification.notification_service.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler() {
+        return new DefaultErrorHandler(new FixedBackOff(1000L, 3L));
+    }
+}

--- a/services/notification-service/src/main/java/com/notification/notification_service/consumer/NotificationConsumer.java
+++ b/services/notification-service/src/main/java/com/notification/notification_service/consumer/NotificationConsumer.java
@@ -1,0 +1,56 @@
+package com.notification.notification_service.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.notification_service.dto.NotificationEvent;
+import com.notification.notification_service.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationConsumer {
+
+    private final NotificationService notificationService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "notification.events", groupId = "notification-service")
+    public void handleNotification(@Payload String message) {
+        log.info("Received notification event: {}", message);
+        try {
+            NotificationEvent event = objectMapper.readValue(message, NotificationEvent.class);
+            notificationService.processNotification(event);
+        } catch (Exception e) {
+            log.error("Error processing notification event: {}", e.getMessage());
+        }
+    }
+
+    @KafkaListener(topics = "order.created", groupId = "notification-service")
+    public void handleOrderCreated(@Payload String message) {
+        log.info("Order created, sending notification: {}", message);
+        try {
+            NotificationEvent event = new NotificationEvent();
+            event.setType("ORDER_CREATED");
+            event.setMessage(message);
+            notificationService.processNotification(event);
+        } catch (Exception e) {
+            log.error("Error processing order.created event: {}", e.getMessage());
+        }
+    }
+
+    @KafkaListener(topics = "payment.success", groupId = "notification-service")
+    public void handlePaymentSuccess(@Payload String message) {
+        log.info("Payment success, sending notification: {}", message);
+        try {
+            NotificationEvent event = new NotificationEvent();
+            event.setType("PAYMENT_SUCCESS");
+            event.setMessage(message);
+            notificationService.processNotification(event);
+        } catch (Exception e) {
+            log.error("Error processing payment.success event: {}", e.getMessage());
+        }
+    }
+}

--- a/services/notification-service/src/main/java/com/notification/notification_service/dto/NotificationEvent.java
+++ b/services/notification-service/src/main/java/com/notification/notification_service/dto/NotificationEvent.java
@@ -1,0 +1,11 @@
+package com.notification.notification_service.dto;
+
+import lombok.Data;
+
+@Data
+public class NotificationEvent {
+    private String orderId;
+    private String userId;
+    private String type;
+    private String message;
+}

--- a/services/notification-service/src/main/java/com/notification/notification_service/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/notification/notification_service/service/NotificationService.java
@@ -1,0 +1,31 @@
+package com.notification.notification_service.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.notification_service.dto.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final ObjectMapper objectMapper;
+
+    public void processNotification(NotificationEvent event) {
+        log.info("Processing notification for order: {}, type: {}", 
+            event.getOrderId(), event.getType());
+
+        switch (event.getType()) {
+            case "ORDER_CREATED" ->
+                log.info("Sending order created notification to user: {}", event.getUserId());
+            case "ORDER_DELIVERED" ->
+                log.info("Sending order delivered notification to user: {}", event.getUserId());
+            case "PAYMENT_SUCCESS" ->
+                log.info("Sending payment success notification to user: {}", event.getUserId());
+            default ->
+                log.warn("Unknown notification type: {}", event.getType());
+        }
+    }
+}

--- a/services/notification-service/src/main/resources/application.yaml
+++ b/services/notification-service/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
+server:
+  port: 8084
+
 spring:
   application:
     name: notification-service
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: notification-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
## Changes
- Add pom.xml with Spring Boot 3.3.0, Kafka, Lombok
- Add application.yaml with Kafka config on port 8084
- Add NotificationEvent DTO
- Add NotificationService with order/payment notification handlers
- Add NotificationConsumer listening to 3 topics:
  - notification.events
  - order.created
  - payment.success
- Add KafkaConfig with ObjectMapper and error handler

## Test
- Service starts successfully on port 8084
- All 3 Kafka consumers connected and assigned partitions