### PR TITLE
 feat(staff-service): implement staff management service

### DIFF
--- a/services/staff-service/pom.xml
+++ b/services/staff-service/pom.xml
@@ -6,101 +6,21 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>4.0.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>com.staff</groupId>
 	<artifactId>staff-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name/>
-	<description/>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+	<name>staff-service</name>
+	<description>Staff Service - Shipper, Driver, Hub/Branch staff management</description>
+
 	<properties>
 		<java.version>21</java.version>
 		<spring-cloud.version>2025.1.1</spring-cloud.version>
+		<mapstruct.version>1.6.3</mapstruct.version>
+		<lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-kafka</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-oauth2-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-openfeign</artifactId>
-		</dependency>
 
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-kafka-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-oauth2-client-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -113,13 +33,132 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<dependencies>
+		<!-- ====== Core ====== -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+		<!-- ====== Security + JWT ====== -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+
+		<!-- ====== Spring Cloud ====== -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
+		</dependency>
+
+		<!-- ====== Kafka ====== -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+
+		<!-- ====== Redis ====== -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+
+		<!-- ====== Code helpers ====== -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${mapstruct.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<!-- ====== Database ====== -->
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- ====== Test ====== -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>${lombok-mapstruct-binding.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${mapstruct.version}</version>
+						</path>
+					</annotationProcessorPaths>
+					<compilerArgs>
+						<arg>-Amapstruct.suppressGeneratorTimestamp=true</arg>
+						<arg>-Amapstruct.defaultComponentModel=spring</arg>
+					</compilerArgs>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/services/staff-service/src/main/java/com/staff/staff_service/StaffServiceApplication.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/StaffServiceApplication.java
@@ -2,8 +2,10 @@ package com.staff.staff_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class StaffServiceApplication {
 
 	public static void main(String[] args) {

--- a/services/staff-service/src/main/java/com/staff/staff_service/config/CustomJwtDecoder.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/config/CustomJwtDecoder.java
@@ -1,0 +1,57 @@
+package com.staff.staff_service.config;
+
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class CustomJwtDecoder implements JwtDecoder {
+
+    @Value("${jwt.signerKey}")
+    private String signerKey;
+
+    @Override
+    public Jwt decode(String token) throws JwtException {
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(token);
+            MACVerifier verifier = new MACVerifier(signerKey.getBytes());
+
+            if (!signedJWT.verify(verifier)) {
+                throw new JwtException("Invalid JWT signature");
+            }
+
+            Date expirationTime = signedJWT.getJWTClaimsSet().getExpirationTime();
+            if (expirationTime != null && expirationTime.before(new Date())) {
+                throw new JwtException("JWT token has expired");
+            }
+
+            var claims = signedJWT.getJWTClaimsSet();
+            Instant issuedAt = claims.getIssueTime() != null ? claims.getIssueTime().toInstant() : Instant.now();
+            Instant expiresAt = expirationTime != null ? expirationTime.toInstant() : Instant.now().plusSeconds(3600);
+
+            return Jwt.withTokenValue(token)
+                    .header("alg", signedJWT.getHeader().getAlgorithm().getName())
+                    .claims(c -> {
+                        try {
+                            c.putAll(claims.toJSONObject());
+                        } catch (Exception e) {
+                            throw new JwtException("Failed to parse JWT claims");
+                        }
+                    })
+                    .issuedAt(issuedAt)
+                    .expiresAt(expiresAt)
+                    .build();
+
+        } catch (ParseException | com.nimbusds.jose.JOSEException e) {
+            throw new JwtException("Failed to decode JWT: " + e.getMessage());
+        }
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/config/JacksonConfig.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.staff.staff_service.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/config/JwtAuthenticationEntryPoint.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.staff.staff_service.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.staff.staff_service.dto.response.ApiResponse;
+import com.staff.staff_service.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = ErrorCode.UNAUTHENTICATED;
+        response.setStatus(errorCode.getStatusCode().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ApiResponse<Void> apiResponse = ApiResponse.<Void>builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+
+        new ObjectMapper().writeValue(response.getWriter(), apiResponse);
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/config/SecurityConfig.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.staff.staff_service.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomJwtDecoder customJwtDecoder;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/internal/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.decoder(customJwtDecoder))
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            );
+
+        return http.build();
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/controller/InternalStaffController.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/controller/InternalStaffController.java
@@ -1,0 +1,32 @@
+package com.staff.staff_service.controller;
+
+import com.staff.staff_service.dto.response.ApiResponse;
+import com.staff.staff_service.dto.response.StaffResponse;
+import com.staff.staff_service.enums.StaffRole;
+import com.staff.staff_service.service.StaffService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class InternalStaffController {
+
+    private final StaffService staffService;
+
+    @GetMapping("/{id}")
+    public ApiResponse<StaffResponse> getById(@PathVariable String id) {
+        return ApiResponse.<StaffResponse>builder()
+                .code(1000).result(staffService.getById(id)).build();
+    }
+
+    @GetMapping("/available")
+    public ApiResponse<List<StaffResponse>> getAvailable(
+            @RequestParam String homeBaseId,
+            @RequestParam StaffRole role) {
+        return ApiResponse.<List<StaffResponse>>builder()
+                .code(1000).result(staffService.getAvailableByHomeBase(homeBaseId, role)).build();
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/controller/StaffController.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/controller/StaffController.java
@@ -1,0 +1,60 @@
+package com.staff.staff_service.controller;
+
+import com.staff.staff_service.dto.request.CreateStaffRequest;
+import com.staff.staff_service.dto.request.UpdateStatusRequest;
+import com.staff.staff_service.dto.response.ApiResponse;
+import com.staff.staff_service.dto.response.StaffResponse;
+import com.staff.staff_service.enums.StaffRole;
+import com.staff.staff_service.service.StaffService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class StaffController {
+
+    private final StaffService staffService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<StaffResponse> create(@Valid @RequestBody CreateStaffRequest request) {
+        return ApiResponse.<StaffResponse>builder()
+                .code(1000).message("Staff created").result(staffService.create(request)).build();
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<StaffResponse> getById(@PathVariable String id) {
+        return ApiResponse.<StaffResponse>builder()
+                .code(1000).result(staffService.getById(id)).build();
+    }
+
+    @GetMapping
+    public ApiResponse<List<StaffResponse>> getAll(
+            @RequestParam(required = false) String homeBaseId,
+            @RequestParam(required = false) StaffRole role) {
+        List<StaffResponse> result;
+        if (homeBaseId != null && role != null) {
+            result = staffService.getAvailableByHomeBase(homeBaseId, role);
+        } else if (homeBaseId != null) {
+            result = staffService.getByHomeBase(homeBaseId);
+        } else if (role != null) {
+            result = staffService.getByRole(role);
+        } else {
+            result = staffService.getAll();
+        }
+        return ApiResponse.<List<StaffResponse>>builder().code(1000).result(result).build();
+    }
+
+    @PatchMapping("/{id}/status")
+    public ApiResponse<StaffResponse> updateStatus(
+            @PathVariable String id,
+            @Valid @RequestBody UpdateStatusRequest request) {
+        return ApiResponse.<StaffResponse>builder()
+                .code(1000).result(staffService.updateStatus(id, request)).build();
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/dto/request/CreateStaffRequest.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/dto/request/CreateStaffRequest.java
@@ -1,0 +1,29 @@
+package com.staff.staff_service.dto.request;
+
+import com.staff.staff_service.enums.HomeBaseType;
+import com.staff.staff_service.enums.StaffRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CreateStaffRequest {
+
+    private String userId;
+
+    @NotBlank
+    private String fullName;
+
+    private String phone;
+
+    private String email;
+
+    @NotNull
+    private StaffRole role;
+
+    @NotBlank
+    private String homeBaseId;
+
+    @NotNull
+    private HomeBaseType homeBaseType;
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/dto/request/UpdateStatusRequest.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/dto/request/UpdateStatusRequest.java
@@ -1,0 +1,12 @@
+package com.staff.staff_service.dto.request;
+
+import com.staff.staff_service.enums.StaffStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class UpdateStatusRequest {
+
+    @NotNull
+    private StaffStatus status;
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/dto/response/ApiResponse.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/dto/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.staff.staff_service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private int code;
+    private String message;
+    private T result;
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/dto/response/StaffResponse.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/dto/response/StaffResponse.java
@@ -1,0 +1,23 @@
+package com.staff.staff_service.dto.response;
+
+import com.staff.staff_service.enums.HomeBaseType;
+import com.staff.staff_service.enums.StaffRole;
+import com.staff.staff_service.enums.StaffStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class StaffResponse {
+    private String id;
+    private String userId;
+    private String fullName;
+    private String phone;
+    private String email;
+    private StaffRole role;
+    private String homeBaseId;
+    private HomeBaseType homeBaseType;
+    private StaffStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/entity/Staff.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/entity/Staff.java
@@ -1,0 +1,58 @@
+package com.staff.staff_service.entity;
+
+import com.staff.staff_service.enums.HomeBaseType;
+import com.staff.staff_service.enums.StaffRole;
+import com.staff.staff_service.enums.StaffStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "staff")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Staff {
+
+    @Id
+    @UuidGenerator
+    private String id;
+
+    @Column(name = "user_id", unique = true)
+    private String userId;
+
+    @Column(name = "full_name", nullable = false, length = 100)
+    private String fullName;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 100)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StaffRole role;
+
+    @Column(name = "home_base_id", nullable = false)
+    private String homeBaseId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "home_base_type", nullable = false, length = 10)
+    private HomeBaseType homeBaseType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private StaffStatus status = StaffStatus.ACTIVE;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/enums/HomeBaseType.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/enums/HomeBaseType.java
@@ -1,0 +1,6 @@
+package com.staff.staff_service.enums;
+
+public enum HomeBaseType {
+    BRANCH,
+    HUB
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/enums/StaffRole.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/enums/StaffRole.java
@@ -1,0 +1,8 @@
+package com.staff.staff_service.enums;
+
+public enum StaffRole {
+    SHIPPER,
+    DRIVER,
+    HUB_STAFF,
+    BRANCH_STAFF
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/enums/StaffStatus.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/enums/StaffStatus.java
@@ -1,0 +1,7 @@
+package com.staff.staff_service.enums;
+
+public enum StaffStatus {
+    ACTIVE,
+    INACTIVE,
+    ON_LEAVE
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/exception/ApplicationException.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/exception/ApplicationException.java
@@ -1,0 +1,13 @@
+package com.staff.staff_service.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ApplicationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/exception/ErrorCode.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.staff.staff_service.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+public enum ErrorCode {
+    UNCATEGORIZED_EXCEPTION(9999, "Uncategorized error", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNAUTHENTICATED(1003, "Unauthenticated", HttpStatus.UNAUTHORIZED),
+    UNAUTHORIZED(1004, "You do not have permission", HttpStatus.FORBIDDEN),
+
+    STAFF_NOT_FOUND(5001, "Staff not found", HttpStatus.NOT_FOUND),
+    STAFF_USER_ALREADY_EXISTS(5002, "User already registered as staff", HttpStatus.BAD_REQUEST),
+
+    INVALID_REQUEST(5099, "Invalid request data", HttpStatus.BAD_REQUEST);
+
+    private final int code;
+    private final String message;
+    private final HttpStatusCode statusCode;
+
+    ErrorCode(int code, String message, HttpStatusCode statusCode) {
+        this.code = code;
+        this.message = message;
+        this.statusCode = statusCode;
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/exception/GlobalExceptionHandler.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.staff.staff_service.exception;
+
+import com.staff.staff_service.dto.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleApp(ApplicationException e) {
+        ErrorCode code = e.getErrorCode();
+        return ResponseEntity.status(code.getStatusCode())
+                .body(ApiResponse.<Void>builder()
+                        .code(code.getCode()).message(code.getMessage()).build());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String msg = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst().orElse("Validation error");
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.<Void>builder()
+                        .code(ErrorCode.INVALID_REQUEST.getCode()).message(msg).build());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity.internalServerError()
+                .body(ApiResponse.<Void>builder()
+                        .code(ErrorCode.UNCATEGORIZED_EXCEPTION.getCode()).message(e.getMessage()).build());
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/kafka/consumer/ShipperAssignedConsumer.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/kafka/consumer/ShipperAssignedConsumer.java
@@ -1,0 +1,30 @@
+package com.staff.staff_service.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.staff.staff_service.kafka.event.ShipperAssignedEvent;
+import com.staff.staff_service.service.StaffService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ShipperAssignedConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final StaffService staffService;
+
+    @KafkaListener(topics = "shipper.assigned", groupId = "staff-service")
+    public void consume(String message) {
+        try {
+            ShipperAssignedEvent event = objectMapper.readValue(message, ShipperAssignedEvent.class);
+            log.info("Shipper {} assigned route {} with {} orders",
+                    event.getShipperId(), event.getRouteId(), event.getTotalOrders());
+            staffService.evictCache(event.getShipperId());
+        } catch (Exception e) {
+            log.error("Failed to process shipper.assigned event: {}", e.getMessage());
+        }
+    }
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/kafka/event/ShipperAssignedEvent.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/kafka/event/ShipperAssignedEvent.java
@@ -1,0 +1,19 @@
+package com.staff.staff_service.kafka.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShipperAssignedEvent {
+    private String routeId;
+    private String shipperId;
+    private String branchId;
+    private String routeType;
+    private LocalDate routeDate;
+    private int totalOrders;
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/mapper/StaffMapper.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/mapper/StaffMapper.java
@@ -1,0 +1,19 @@
+package com.staff.staff_service.mapper;
+
+import com.staff.staff_service.dto.request.CreateStaffRequest;
+import com.staff.staff_service.dto.response.StaffResponse;
+import com.staff.staff_service.entity.Staff;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface StaffMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Staff toEntity(CreateStaffRequest request);
+
+    StaffResponse toResponse(Staff staff);
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/repository/StaffRepository.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/repository/StaffRepository.java
@@ -1,0 +1,26 @@
+package com.staff.staff_service.repository;
+
+import com.staff.staff_service.entity.Staff;
+import com.staff.staff_service.enums.StaffRole;
+import com.staff.staff_service.enums.StaffStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StaffRepository extends JpaRepository<Staff, String> {
+
+    List<Staff> findByRole(StaffRole role);
+
+    List<Staff> findByHomeBaseId(String homeBaseId);
+
+    List<Staff> findByHomeBaseIdAndRole(String homeBaseId, StaffRole role);
+
+    List<Staff> findByHomeBaseIdAndRoleAndStatus(String homeBaseId, StaffRole role, StaffStatus status);
+
+    List<Staff> findByRoleAndStatus(StaffRole role, StaffStatus status);
+
+    Optional<Staff> findByUserId(String userId);
+
+    boolean existsByUserId(String userId);
+}

--- a/services/staff-service/src/main/java/com/staff/staff_service/service/StaffService.java
+++ b/services/staff-service/src/main/java/com/staff/staff_service/service/StaffService.java
@@ -1,0 +1,111 @@
+package com.staff.staff_service.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.staff.staff_service.dto.request.CreateStaffRequest;
+import com.staff.staff_service.dto.request.UpdateStatusRequest;
+import com.staff.staff_service.dto.response.StaffResponse;
+import com.staff.staff_service.entity.Staff;
+import com.staff.staff_service.enums.StaffRole;
+import com.staff.staff_service.enums.StaffStatus;
+import com.staff.staff_service.exception.ApplicationException;
+import com.staff.staff_service.exception.ErrorCode;
+import com.staff.staff_service.mapper.StaffMapper;
+import com.staff.staff_service.repository.StaffRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StaffService {
+
+    private static final String CACHE_PREFIX = "staff:";
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+
+    private final StaffRepository staffRepository;
+    private final StaffMapper staffMapper;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public StaffResponse create(CreateStaffRequest request) {
+        if (request.getUserId() != null && staffRepository.existsByUserId(request.getUserId())) {
+            throw new ApplicationException(ErrorCode.STAFF_USER_ALREADY_EXISTS);
+        }
+        Staff staff = staffMapper.toEntity(request);
+        staff = staffRepository.save(staff);
+        StaffResponse response = staffMapper.toResponse(staff);
+        cacheStaff(response);
+        return response;
+    }
+
+    public StaffResponse getById(String id) {
+        String cached = redisTemplate.opsForValue().get(CACHE_PREFIX + id);
+        if (cached != null) {
+            try {
+                return objectMapper.readValue(cached, StaffResponse.class);
+            } catch (JsonProcessingException e) {
+                log.warn("Failed to deserialize cached staff {}", id);
+            }
+        }
+        Staff staff = staffRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.STAFF_NOT_FOUND));
+        StaffResponse response = staffMapper.toResponse(staff);
+        cacheStaff(response);
+        return response;
+    }
+
+    public List<StaffResponse> getAll() {
+        return staffRepository.findAll().stream()
+                .map(staffMapper::toResponse)
+                .toList();
+    }
+
+    public List<StaffResponse> getByHomeBase(String homeBaseId) {
+        return staffRepository.findByHomeBaseId(homeBaseId).stream()
+                .map(staffMapper::toResponse)
+                .toList();
+    }
+
+    public List<StaffResponse> getAvailableByHomeBase(String homeBaseId, StaffRole role) {
+        return staffRepository.findByHomeBaseIdAndRoleAndStatus(homeBaseId, role, StaffStatus.ACTIVE).stream()
+                .map(staffMapper::toResponse)
+                .toList();
+    }
+
+    public List<StaffResponse> getByRole(StaffRole role) {
+        return staffRepository.findByRole(role).stream()
+                .map(staffMapper::toResponse)
+                .toList();
+    }
+
+    public StaffResponse updateStatus(String id, UpdateStatusRequest request) {
+        Staff staff = staffRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.STAFF_NOT_FOUND));
+        staff.setStatus(request.getStatus());
+        staff = staffRepository.save(staff);
+        StaffResponse response = staffMapper.toResponse(staff);
+        cacheStaff(response);
+        return response;
+    }
+
+    private void cacheStaff(StaffResponse response) {
+        try {
+            redisTemplate.opsForValue().set(
+                    CACHE_PREFIX + response.getId(),
+                    objectMapper.writeValueAsString(response),
+                    CACHE_TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to cache staff {}", response.getId());
+        }
+    }
+
+    public void evictCache(String id) {
+        redisTemplate.delete(CACHE_PREFIX + id);
+    }
+}

--- a/services/staff-service/src/test/resources/application.yml
+++ b/services/staff-service/src/test/resources/application.yml
@@ -16,4 +16,4 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 
 jwt:
-  signer-key: test-signer-key-for-unit-testing-only-must-be-at-least-32-bytes
+  signerKey: test-signer-key-for-unit-testing-only-must-be-at-least-32-bytes


### PR DESCRIPTION
- Entities: Staff with StaffRole, StaffStatus, HomeBaseType enums
- Repository: queries by role, homeBase, status combinations
- Service: CRUD with Redis cache (10 min TTL)
- Controllers: /staff (authenticated) + /internal (no auth)
- Kafka consumer: shipper.assigned → evict cache
- Config: JWT (signerKey), Security, Jackson
- pom.xml: replace invalid starters with proper deps + Lombok/MapStruct