### PR TITLE
feat(frontend): integrate real auth API replacing mock auth

### DIFF
--- a/apps/apps/admin-web/src/app/login/page.tsx
+++ b/apps/apps/admin-web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Package, Mail, Lock, Eye, EyeOff, ArrowRight, ShieldCheck } from "lucide-react";
+import { apiLogin } from "@picbox/utils";
 
 /* ─────────────────────────────────────────────
    Spinner component
@@ -66,15 +67,15 @@ export default function LoginPage() {
     setError("");
     setLoading(true);
 
-    await new Promise((r) => setTimeout(r, 1400));
-
-    if (email === "admin" && password === "123456") {
-      localStorage.setItem("accessToken", "demo-token");
-      localStorage.setItem("user", JSON.stringify({ name: "Admin", role: "admin" }));
+    try {
+      const { token, user } = await apiLogin(email, password);
+      localStorage.setItem("accessToken", token);
+      localStorage.setItem("user", JSON.stringify(user));
+      document.cookie = `auth_token=${token};path=/;max-age=86400`;
       router.push("/");
-    } else {
+    } catch (err: unknown) {
       setLoading(false);
-      setError("Tài khoản hoặc mật khẩu không chính xác.");
+      setError(err instanceof Error ? err.message : "Tài khoản hoặc mật khẩu không chính xác.");
       triggerShake();
     }
   }

--- a/apps/packages/utils/src/api-client.ts
+++ b/apps/packages/utils/src/api-client.ts
@@ -35,25 +35,25 @@ apiClient.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const refreshToken = localStorage.getItem("refreshToken");
-        if (!refreshToken) {
-          throw new Error("No refresh token");
-        }
+        const currentToken = localStorage.getItem("accessToken");
+        if (!currentToken) throw new Error("No token");
 
-        const { data } = await axios.post(`${API_BASE_URL}/api/auth/refresh`, {
-          refreshToken,
+        const { data } = await axios.post(`${API_BASE_URL}/identity/auth/refreshToken`, {
+          token: currentToken,
         });
 
-        localStorage.setItem("accessToken", data.data.accessToken);
-        localStorage.setItem("refreshToken", data.data.refreshToken);
+        const newToken: string = data.result.token;
+        localStorage.setItem("accessToken", newToken);
+        document.cookie = `auth_token=${newToken};path=/;max-age=86400`;
 
-        originalRequest.headers.Authorization = `Bearer ${data.data.accessToken}`;
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
         return apiClient(originalRequest);
       } catch (refreshError) {
         localStorage.removeItem("accessToken");
-        localStorage.removeItem("refreshToken");
+        localStorage.removeItem("user");
+        document.cookie = "auth_token=;path=/;max-age=0";
         if (typeof window !== "undefined") {
-          window.location.href = "/login";
+          window.location.href = "/auth/login";
         }
         return Promise.reject(refreshError);
       }

--- a/apps/packages/utils/src/auth-api.ts
+++ b/apps/packages/utils/src/auth-api.ts
@@ -1,0 +1,119 @@
+import axios from "axios";
+import type { User, UserRole } from "@picbox/types";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+// ─── JWT decode (no library needed) ─────────────────────────────────────────
+
+function decodeJwt(token: string): Record<string, unknown> {
+  try {
+    const payload = token.split(".")[1];
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    return JSON.parse(json);
+  } catch {
+    return {};
+  }
+}
+
+function scopeToRole(scope: string): UserRole {
+  const s = (scope || "").toUpperCase();
+  if (s.includes("ADMIN")) return "admin";
+  if (s.includes("OPS")) return "ops";
+  if (s.includes("SHIPPER")) return "shipper";
+  if (s.includes("DRIVER")) return "driver";
+  return "sender";
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface AuthResult {
+  token: string;
+  user: User;
+}
+
+// ─── API calls ───────────────────────────────────────────────────────────────
+
+export async function apiLogin(username: string, password: string): Promise<AuthResult> {
+  const { data } = await axios.post(`${API_BASE}/identity/auth/token`, { username, password });
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Đăng nhập thất bại");
+  }
+  const token: string = data.result.token;
+  const claims = decodeJwt(token);
+  const userId = claims.sub as string;
+  const scope = (claims.scope as string) || "";
+
+  // Fetch profile for display name
+  let fullName = username;
+  let phone = "";
+  let avatarUrl: string | undefined;
+  try {
+    const profileRes = await axios.get(
+      `${API_BASE}/profile/profiles/getProfile/fromUserId/${userId}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    const p = profileRes.data?.result;
+    if (p) {
+      fullName = p.fullName || p.firstName || username;
+      phone = p.phone || p.phoneNumber || "";
+      avatarUrl = p.avatarUrl || p.avatar;
+    }
+  } catch {
+    // Profile fetch is best-effort; continue with username as fallback
+  }
+
+  const user: User = {
+    id: userId,
+    email: username.includes("@") ? username : "",
+    fullName,
+    phone,
+    role: scopeToRole(scope),
+    status: "active",
+    avatarUrl,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  return { token, user };
+}
+
+export async function apiRegister(params: {
+  username: string;
+  password: string;
+  fullName: string;
+  phone: string;
+}): Promise<void> {
+  const { data } = await axios.post(`${API_BASE}/identity/users/createUser`, {
+    username: params.username,
+    password: params.password,
+    gender: "",
+  });
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Đăng ký thất bại");
+  }
+
+  // Create profile (best-effort; non-fatal if it fails)
+  try {
+    await axios.post(`${API_BASE}/profile/profiles/Internal/createProfile`, {
+      userId: data.result?.id,
+      fullName: params.fullName,
+      phone: params.phone,
+      email: params.username.includes("@") ? params.username : "",
+    });
+  } catch {
+    // profile creation failure is non-fatal for registration
+  }
+}
+
+export async function apiLogout(token: string): Promise<void> {
+  try {
+    await axios.post(`${API_BASE}/identity/auth/logout`, { token });
+  } catch {
+    // Ignore logout errors — clear local state regardless
+  }
+}
+
+export async function apiRefreshToken(token: string): Promise<string> {
+  const { data } = await axios.post(`${API_BASE}/identity/auth/refreshToken`, { token });
+  return data.result.token as string;
+}

--- a/apps/packages/utils/src/index.ts
+++ b/apps/packages/utils/src/index.ts
@@ -1,2 +1,4 @@
 export { apiClient } from "./api-client";
 export { getAuthState, setAuthData, clearAuthData, hasRole, isAdmin } from "./auth";
+export { apiLogin, apiLogout, apiRegister, apiRefreshToken } from "./auth-api";
+export type { AuthResult } from "./auth-api";

--- a/apps/sender-web/app/auth/login/page.tsx
+++ b/apps/sender-web/app/auth/login/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Eye, EyeOff, AlertCircle, Loader2 } from 'lucide-react'
-import { mockLogin } from '@/lib/mock-auth'
+import { login } from '@/lib/auth-service'
 
 export default function LoginPage() {
   const router = useRouter()
@@ -22,11 +22,7 @@ export default function LoginPage() {
     if (!password.trim()) return setError('Vui lòng nhập mật khẩu')
 
     setLoading(true)
-
-    // Giả lập độ trễ network 600ms cho giống thật
-    await new Promise(r => setTimeout(r, 600))
-
-    const result = mockLogin(identifier.trim(), password)
+    const result = await login(identifier.trim(), password)
 
     if (result.ok) {
       router.push('/dashboard')

--- a/apps/sender-web/app/auth/register/page.tsx
+++ b/apps/sender-web/app/auth/register/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Eye, EyeOff, AlertCircle, CheckCircle, Loader2 } from 'lucide-react'
-import { mockRegister } from '@/lib/mock-auth'
+import { register } from '@/lib/auth-service'
 
 function PasswordStrength({ password }: { password: string }) {
   const checks = [
@@ -76,8 +76,7 @@ export default function RegisterPage() {
     const errs = validate()
     if (Object.keys(errs).length > 0) { setErrors(errs); return }
     setLoading(true)
-    await new Promise(r => setTimeout(r, 700))
-    const result = mockRegister({ name: name.trim(), email: email.trim(), phone: phone.trim(), password })
+    const result = await register({ name: name.trim(), email: email.trim(), phone: phone.trim(), password })
     if (result.ok) {
       router.push('/auth/login?registered=1')
     } else {

--- a/apps/sender-web/components/layout/Navbar.tsx
+++ b/apps/sender-web/components/layout/Navbar.tsx
@@ -1,70 +1,102 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Bell, ChevronDown } from 'lucide-react'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { logout, getCurrentUser } from '@/lib/auth-service'
 
 const PAGE_TITLES: Record<string, string> = {
-  '/dashboard':   'Dashboard',
-  '/orders':      'Đơn hàng',
-  '/orders/new':  'Tạo đơn mới',
-  '/wallet':      'Ví của tôi',
-  '/wallet/topup':   'Nạp tiền',
-  '/wallet/history': 'Lịch sử giao dịch',
-  '/settings':    'Cài đặt',
+  '/dashboard':       'Dashboard',
+  '/orders':          'Đơn hàng',
+  '/orders/new':      'Tạo đơn mới',
+  '/wallet':          'Ví của tôi',
+  '/wallet/topup':    'Nạp tiền',
+  '/wallet/history':  'Lịch sử giao dịch',
+  '/settings':        'Cài đặt',
 }
 
 export default function Navbar() {
   const pathname = usePathname()
+  const router = useRouter()
   const [showMenu, setShowMenu] = useState(false)
+  const [user, setUser] = useState<{ name: string; email: string } | null>(null)
+
+  useEffect(() => {
+    setUser(getCurrentUser())
+  }, [])
 
   const title = PAGE_TITLES[pathname] ?? 'ShipNow'
+  const initials = user?.name
+    ? user.name.split(' ').map(w => w[0]).slice(-2).join('').toUpperCase()
+    : '?'
+
+  const handleLogout = async () => {
+    setShowMenu(false)
+    await logout()
+    router.push('/auth/login')
+  }
 
   return (
     <header className="h-14 bg-white border-b border-gray-200 px-4 md:px-6 flex items-center justify-between flex-shrink-0 relative">
       {/* Mobile: space cho hamburger button */}
       <div className="w-8 md:hidden" />
 
-      {/* Title - giữa trên mobile, trái trên desktop */}
+      {/* Title */}
       <span className="absolute left-1/2 -translate-x-1/2 md:static md:translate-x-0 text-sm font-semibold text-gray-800 md:text-gray-500 md:font-normal">
         {title}
       </span>
 
       {/* Right side */}
       <div className="flex items-center gap-2 ml-auto">
-        <button className="relative w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors">
+        <button
+          type="button"
+          aria-label="Thông báo"
+          className="relative w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+        >
           <Bell size={18} />
           <span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full" />
         </button>
 
         <div className="relative">
           <button
+            type="button"
+            aria-label="Menu tài khoản"
             onClick={() => setShowMenu(!showMenu)}
             className="flex items-center gap-2 pl-2 pr-1 py-1 rounded-lg hover:bg-gray-100 transition-colors"
           >
             <div className="w-7 h-7 rounded-full bg-blue-100 flex items-center justify-center text-xs font-bold text-blue-700">
-              VL
+              {initials}
             </div>
             <ChevronDown size={14} className="text-gray-400 hidden sm:block" />
           </button>
 
           {showMenu && (
             <>
-              <div className="fixed inset-0 z-10" onClick={() => setShowMenu(false)} />
+              <div
+                className="fixed inset-0 z-10"
+                aria-hidden="true"
+                onClick={() => setShowMenu(false)}
+              />
               <div className="absolute right-0 top-10 z-20 bg-white border border-gray-200 rounded-xl shadow-lg py-1 w-44">
                 <div className="px-3 py-2 border-b border-gray-100">
-                  <p className="text-sm font-semibold text-gray-900">Nguyễn Đức Vĩ</p>
-                  <p className="text-xs text-gray-500 truncate">ducvi@email.com</p>
+                  <p className="text-sm font-semibold text-gray-900 truncate">{user?.name ?? '—'}</p>
+                  <p className="text-xs text-gray-500 truncate">{user?.email ?? ''}</p>
                 </div>
-                <Link href="/settings" onClick={() => setShowMenu(false)}
-                  className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                <Link
+                  href="/settings"
+                  onClick={() => setShowMenu(false)}
+                  className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                >
                   Cài đặt tài khoản
                 </Link>
-                <Link href="/auth/login" onClick={() => setShowMenu(false)}
-                  className="flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors">
+                <button
+                  type="button"
+                  onClick={handleLogout}
+                  className="w-full text-left flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                >
                   Đăng xuất
-                </Link>
+                </button>
               </div>
             </>
           )}

--- a/apps/sender-web/lib/auth-service.ts
+++ b/apps/sender-web/lib/auth-service.ts
@@ -1,0 +1,79 @@
+import { apiLogin, apiLogout, apiRegister } from "@picbox/utils";
+
+// ─── Cookie helper (middleware reads auth_token cookie) ──────────────────────
+
+function setCookie(name: string, value: string, maxAge = 86400) {
+  document.cookie = `${name}=${value};path=/;max-age=${maxAge}`;
+}
+
+function clearCookie(name: string) {
+  document.cookie = `${name}=;path=/;max-age=0`;
+}
+
+// ─── Login ───────────────────────────────────────────────────────────────────
+
+export async function login(
+  identifier: string,
+  password: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const { token, user } = await apiLogin(identifier, password);
+    localStorage.setItem("accessToken", token);
+    localStorage.setItem("user", JSON.stringify(user));
+    setCookie("auth_token", token);
+    return { ok: true };
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error ? err.message : "Đăng nhập thất bại";
+    return { ok: false, error: message };
+  }
+}
+
+// ─── Register ────────────────────────────────────────────────────────────────
+
+export async function register(params: {
+  name: string;
+  email: string;
+  phone: string;
+  password: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await apiRegister({
+      username: params.email,
+      password: params.password,
+      fullName: params.name,
+      phone: params.phone,
+    });
+    return { ok: true };
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error ? err.message : "Đăng ký thất bại";
+    return { ok: false, error: message };
+  }
+}
+
+// ─── Logout ──────────────────────────────────────────────────────────────────
+
+export async function logout(): Promise<void> {
+  const token = localStorage.getItem("accessToken") ?? "";
+  await apiLogout(token);
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("user");
+  clearCookie("auth_token");
+}
+
+// ─── Get current user display info ───────────────────────────────────────────
+
+export function getCurrentUser(): { name: string; email: string } | null {
+  try {
+    const raw = localStorage.getItem("user");
+    if (!raw) return null;
+    const u = JSON.parse(raw);
+    return {
+      name: u.fullName || u.username || "Người dùng",
+      email: u.email || "",
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/sender-web/middleware.ts
+++ b/apps/sender-web/middleware.ts
@@ -6,13 +6,6 @@ const PUBLIC_PATHS = ['/auth/login', '/auth/register', '/auth/forgot-password', 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // ─── DEV MODE: bỏ qua auth để test UI thoải mái ─────────────
-  // Xóa hoặc comment block này khi deploy production
-  if (process.env.NODE_ENV === 'development') {
-    return NextResponse.next()
-  }
-  // ─────────────────────────────────────────────────────────────
-
   const token = request.cookies.get('auth_token')?.value
 
   if (PUBLIC_PATHS.some(p => pathname.startsWith(p))) {


### PR DESCRIPTION
## Summary
- Add `auth-api.ts` in `@picbox/utils`: `apiLogin`, `apiRegister`, `apiLogout`, `apiRefreshToken` calling identity-service + profile-service
- Add `sender-web/lib/auth-service.ts`: thin wrappers with localStorage + cookie management for Next.js middleware
- Replace `mockLogin`/`mockRegister` in sender-web login and register pages
- Update `Navbar` to read real user info and trigger real logout
- Remove dev bypass in `middleware.ts` — auth guard now enforced in all environments
- Replace hardcoded `admin/123456` in admin-web with real `apiLogin()` call
- Fix `api-client.ts` refresh endpoint: `POST /identity/auth/refreshToken` with `{token}` body, parse `data.result.token`

## Notes
- Login flow: `POST /identity/auth/token` → decode JWT (`sub` = userId, `scope` = roles) → fetch profile (best-effort) → store token in localStorage + cookie `auth_token`
- No separate refresh token — same token used for both access and refresh
