### PR TITLE
feat(frontend): integrate real order API replacing mock data

### DIFF
--- a/apps/packages/utils/src/index.ts
+++ b/apps/packages/utils/src/index.ts
@@ -2,3 +2,10 @@ export { apiClient } from "./api-client";
 export { getAuthState, setAuthData, clearAuthData, hasRole, isAdmin } from "./auth";
 export { apiLogin, apiLogout, apiRegister, apiRefreshToken } from "./auth-api";
 export type { AuthResult } from "./auth-api";
+export {
+  createOrder, getMyOrders, getOrder, getOrderByTracking,
+  cancelOrder, getOrderHistory,
+  toFrontendStatus, toBackendStatus,
+  BRANCH_LIST,
+} from "./order-api";
+export type { CreateOrderParams, OrderPage, OrderHistoryEvent, Branch } from "./order-api";

--- a/apps/packages/utils/src/order-api.ts
+++ b/apps/packages/utils/src/order-api.ts
@@ -1,0 +1,250 @@
+import { apiClient } from "./api-client";
+import type { Order, OrderStatus } from "@picbox/types";
+
+// ─── Backend status enum (15 values) ────────────────────────────────────────
+
+export type BackendOrderStatus =
+  | "PENDING"
+  | "CONFIRMED"
+  | "PICKED_UP"
+  | "AT_ORIGIN_BRANCH"
+  | "IN_TRANSIT_TO_HUB"
+  | "AT_HUB"
+  | "IN_TRANSIT_TO_DEST_HUB"
+  | "AT_DEST_HUB"
+  | "IN_TRANSIT_TO_DEST_BRANCH"
+  | "AT_DEST_BRANCH"
+  | "OUT_FOR_DELIVERY"
+  | "DELIVERED"
+  | "DELIVERY_FAILED"
+  | "RETURNED"
+  | "CANCELLED";
+
+const BE_TO_FE: Record<BackendOrderStatus, OrderStatus> = {
+  PENDING:                  "pending",
+  CONFIRMED:                "confirmed",
+  PICKED_UP:                "picked_up",
+  AT_ORIGIN_BRANCH:         "picked_up",
+  IN_TRANSIT_TO_HUB:        "in_transit",
+  AT_HUB:                   "at_hub",
+  IN_TRANSIT_TO_DEST_HUB:   "at_hub",
+  AT_DEST_HUB:              "at_hub",
+  IN_TRANSIT_TO_DEST_BRANCH:"in_transit",
+  AT_DEST_BRANCH:           "sorting",
+  OUT_FOR_DELIVERY:         "out_for_delivery",
+  DELIVERED:                "delivered",
+  DELIVERY_FAILED:          "failed",
+  RETURNED:                 "returned",
+  CANCELLED:                "cancelled",
+};
+
+const FE_TO_BE: Record<OrderStatus, BackendOrderStatus> = {
+  pending:          "PENDING",
+  confirmed:        "CONFIRMED",
+  picked_up:        "PICKED_UP",
+  in_transit:       "IN_TRANSIT_TO_HUB",
+  at_hub:           "AT_HUB",
+  sorting:          "AT_DEST_BRANCH",
+  out_for_delivery: "OUT_FOR_DELIVERY",
+  delivered:        "DELIVERED",
+  failed:           "DELIVERY_FAILED",
+  returned:         "RETURNED",
+  cancelled:        "CANCELLED",
+};
+
+export function toFrontendStatus(s: string): OrderStatus {
+  return BE_TO_FE[s as BackendOrderStatus] ?? "pending";
+}
+
+export function toBackendStatus(s: OrderStatus): BackendOrderStatus {
+  return FE_TO_BE[s] ?? "PENDING";
+}
+
+// ─── Branch list (replace with GET /hub/branches when hub-service is ready) ──
+
+export interface Branch {
+  id: string;
+  name: string;
+}
+
+export const BRANCH_LIST: Branch[] = [
+  { id: "HCM_01", name: "Chi nhánh TP.HCM - Quận 1" },
+  { id: "HAN_01", name: "Chi nhánh Hà Nội - Hoàn Kiếm" },
+  { id: "DN_01",  name: "Chi nhánh Đà Nẵng" },
+  { id: "CT_01",  name: "Chi nhánh Cần Thơ" },
+  { id: "HP_01",  name: "Chi nhánh Hải Phòng" },
+];
+
+// ─── Backend response shape ──────────────────────────────────────────────────
+
+interface BackendOrder {
+  id: string;
+  trackingCode: string;
+  senderId: string;
+  senderName: string;
+  senderPhone: string;
+  receiverName: string;
+  receiverPhone: string;
+  receiverAddress: string;
+  originBranchId: string;
+  originBranchName: string;
+  destBranchId: string;
+  destBranchName: string;
+  weight: number;
+  width?: number;
+  height?: number;
+  length?: number;
+  fee: number;
+  codAmount?: number;
+  pickupMethod: "PICKUP_AT_BRANCH" | "PICKUP_AT_DOOR";
+  status: string;
+  regionCode?: string;
+  shipperId?: string;
+  note?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+// ─── Adapter: BackendOrder → Order (frontend type) ───────────────────────────
+
+function adapt(o: BackendOrder): Order {
+  const dims = [o.length, o.width, o.height]
+    .filter(Boolean)
+    .map(d => `${d}cm`)
+    .join(" × ");
+  return {
+    id:              o.id,
+    trackingCode:    o.trackingCode,
+    senderId:        o.senderId,
+    senderName:      o.senderName,
+    senderPhone:     o.senderPhone,
+    senderAddress:   o.originBranchName,
+    receiverName:    o.receiverName,
+    receiverPhone:   o.receiverPhone,
+    receiverAddress: o.receiverAddress,
+    weight:          o.weight,
+    dimensions:      dims || undefined,
+    note:            o.note,
+    codAmount:       o.codAmount ?? 0,
+    shippingFee:     o.fee,
+    status:          toFrontendStatus(o.status),
+    createdAt:       o.createdAt,
+    updatedAt:       o.updatedAt,
+  };
+}
+
+// ─── Paged result ─────────────────────────────────────────────────────────────
+
+export interface OrderPage {
+  orders: Order[];
+  totalElements: number;
+  totalPages: number;
+  page: number;
+  size: number;
+}
+
+// ─── Create order params ──────────────────────────────────────────────────────
+
+export interface CreateOrderParams {
+  senderName: string;
+  senderPhone: string;
+  receiverName: string;
+  receiverPhone: string;
+  receiverAddress: string;
+  destBranchId: string;
+  destBranchName: string;
+  originBranchId: string;
+  originBranchName: string;
+  weight: number;
+  width?: number;
+  height?: number;
+  length?: number;
+  fee: number;
+  codAmount?: number;
+  pickupMethod?: "PICKUP_AT_BRANCH" | "PICKUP_AT_DOOR";
+  note?: string;
+}
+
+// ─── API functions ────────────────────────────────────────────────────────────
+
+export async function createOrder(params: CreateOrderParams): Promise<Order> {
+  const { data } = await apiClient.post("/order/orders", {
+    ...params,
+    pickupMethod: params.pickupMethod ?? "PICKUP_AT_DOOR",
+  });
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Tạo đơn hàng thất bại");
+  }
+  return adapt(data.result as BackendOrder);
+}
+
+export async function getMyOrders(page = 0, size = 50): Promise<OrderPage> {
+  const { data } = await apiClient.get("/order/orders/my", {
+    params: { page, size },
+  });
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Không thể tải danh sách đơn");
+  }
+  const pr = data.result as PageResponse<BackendOrder>;
+  return {
+    orders:        pr.content.map(adapt),
+    totalElements: pr.totalElements,
+    totalPages:    pr.totalPages,
+    page:          pr.page,
+    size:          pr.size,
+  };
+}
+
+export async function getOrder(orderId: string): Promise<Order> {
+  const { data } = await apiClient.get(`/order/orders/${orderId}`);
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Không tìm thấy đơn hàng");
+  }
+  return adapt(data.result as BackendOrder);
+}
+
+export async function getOrderByTracking(trackingCode: string): Promise<Order> {
+  const { data } = await apiClient.get(
+    `/order/orders/tracking/${trackingCode}`
+  );
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Không tìm thấy vận đơn");
+  }
+  return adapt(data.result as BackendOrder);
+}
+
+export async function cancelOrder(orderId: string): Promise<void> {
+  const { data } = await apiClient.delete(`/order/orders/${orderId}`);
+  if (data.code !== 1000 && data.code !== 0) {
+    throw new Error(data.message || "Không thể huỷ đơn hàng");
+  }
+}
+
+export interface OrderHistoryEvent {
+  status: OrderStatus;
+  note?: string;
+  timestamp: string;
+  updatedBy?: string;
+}
+
+export async function getOrderHistory(
+  orderId: string
+): Promise<OrderHistoryEvent[]> {
+  const { data } = await apiClient.get(`/order/orders/${orderId}/history`);
+  if (data.code !== 1000 && data.code !== 0) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (data.result as any[]).map((h) => ({
+    status:    toFrontendStatus(h.status),
+    note:      h.note,
+    timestamp: h.createdAt ?? h.timestamp,
+    updatedBy: h.updatedBy,
+  }));
+}

--- a/apps/sender-web/app/(dashboard)/orders/[id]/page.tsx
+++ b/apps/sender-web/app/(dashboard)/orders/[id]/page.tsx
@@ -2,216 +2,19 @@
 
 import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import {
   Home, ChevronRight, ArrowLeft, Package,
   MapPin, Phone, User, Banknote, Clock,
   CheckCircle, Truck, RotateCcw, XCircle,
-  Copy, ExternalLink, AlertCircle
+  Copy, ExternalLink, AlertCircle, Loader2
 } from 'lucide-react'
 import { ToastContainer, useToast } from '@/components/ui/toast'
+import { getOrder, getOrderHistory, cancelOrder } from '@picbox/utils'
+import type { OrderHistoryEvent } from '@picbox/utils'
+import type { Order } from '@picbox/types'
 
-// ---- Types ----
-type OrderStatus =
-  | 'pending' | 'confirmed' | 'picked_up' | 'in_transit'
-  | 'at_hub' | 'sorting' | 'out_for_delivery' | 'delivering'
-  | 'delivered' | 'failed' | 'returned' | 'cancelled'
-
-interface TimelineEvent {
-  status: string
-  label: string
-  time: string
-  location?: string
-  done: boolean
-  active: boolean
-}
-
-interface OrderData {
-  id: string
-  trackingCode: string
-  status: OrderStatus
-  createdAt: string
-  updatedAt: string
-  serviceType: string
-  estimatedDelivery: string
-  sender: { name: string; phone: string; address: string }
-  receiver: { name: string; phone: string; address: string; province: string }
-  package: { weight: number; description: string; value: number }
-  codAmount: number
-  shippingFee: number
-  paymentSide: 'sender' | 'receiver'
-  note: string
-  timeline: TimelineEvent[]
-}
-
-// ---- Mock data — đầy đủ 10 đơn (khớp với danh sách orders) ----
-const MOCK_ORDERS: Record<string, OrderData> = {
-  '1': {
-    id: '1', trackingCode: 'PB001234', status: 'out_for_delivery',
-    createdAt: '15/05/2026 08:00', updatedAt: '15/05/2026 14:30',
-    serviceType: 'Nhanh', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Nguyễn Văn A', phone: '0901234567', address: '45 Trần Hưng Đạo', province: 'Quận 5, TP.HCM' },
-    package: { weight: 1.5, description: 'Quần áo', value: 350000 },
-    codAmount: 250000, shippingFee: 35000, paymentSide: 'receiver',
-    note: 'Gọi trước khi giao',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '15/05/2026 08:05', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '15/05/2026 10:20', location: 'Quận 1, TP.HCM', done: true, active: false },
-      { status: 'at_hub', label: 'Hàng đến bưu cục', time: '15/05/2026 11:45', location: 'Hub Q.1 - TP.HCM', done: true, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '15/05/2026 13:30', location: 'Quận 5, TP.HCM', done: true, active: true },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '—', location: '', done: false, active: false },
-    ],
-  },
-  '2': {
-    id: '2', trackingCode: 'PB001235', status: 'delivered',
-    createdAt: '14/05/2026 09:00', updatedAt: '15/05/2026 14:30',
-    serviceType: 'Tiêu chuẩn', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Trần Thị B', phone: '0912345678', address: '22 Hai Bà Trưng', province: 'Quận 3, TP.HCM' },
-    package: { weight: 0.5, description: 'Mỹ phẩm', value: 0 },
-    codAmount: 0, shippingFee: 20000, paymentSide: 'sender',
-    note: '',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '14/05/2026 09:10', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '14/05/2026 11:00', location: 'Quận 1, TP.HCM', done: true, active: false },
-      { status: 'at_hub', label: 'Hàng đến bưu cục', time: '14/05/2026 13:00', location: 'Hub Q.1 - TP.HCM', done: true, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '15/05/2026 08:00', location: 'Quận 3, TP.HCM', done: true, active: false },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '15/05/2026 14:30', location: 'Quận 3, TP.HCM', done: true, active: true },
-    ],
-  },
-  '3': {
-    id: '3', trackingCode: 'PB001236', status: 'pending',
-    createdAt: '15/05/2026 07:00', updatedAt: '15/05/2026 07:05',
-    serviceType: 'Nhanh', estimatedDelivery: '16/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Lê Văn C', phone: '0923456789', address: '88 Đinh Tiên Hoàng', province: 'Bình Thạnh, TP.HCM' },
-    package: { weight: 2.0, description: 'Đồ điện tử', value: 1500000 },
-    codAmount: 500000, shippingFee: 35000, paymentSide: 'receiver',
-    note: '',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '15/05/2026 07:05', location: 'Hệ thống', done: true, active: true },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '—', location: '', done: false, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '—', location: '', done: false, active: false },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '—', location: '', done: false, active: false },
-    ],
-  },
-  '4': {
-    id: '4', trackingCode: 'PB001237', status: 'returned',
-    createdAt: '14/05/2026 15:00', updatedAt: '15/05/2026 10:00',
-    serviceType: 'Tiêu chuẩn', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Phạm Thị D', phone: '0934567890', address: '15 Lê Văn Sỹ', province: 'Gò Vấp, TP.HCM' },
-    package: { weight: 3.0, description: 'Giày dép', value: 800000 },
-    codAmount: 150000, shippingFee: 40000, paymentSide: 'receiver',
-    note: 'Hàng dễ vỡ',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '14/05/2026 15:05', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '14/05/2026 17:00', location: 'Quận 1, TP.HCM', done: true, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '15/05/2026 09:00', location: 'Gò Vấp, TP.HCM', done: true, active: false },
-      { status: 'failed', label: 'Giao thất bại - Không liên lạc được', time: '15/05/2026 09:45', location: 'Gò Vấp, TP.HCM', done: true, active: false },
-      { status: 'returned', label: 'Đang hoàn hàng về người gửi', time: '15/05/2026 10:00', location: 'Gò Vấp, TP.HCM', done: true, active: true },
-    ],
-  },
-  '5': {
-    id: '5', trackingCode: 'PB001238', status: 'confirmed',
-    createdAt: '14/05/2026 14:00', updatedAt: '14/05/2026 14:10',
-    serviceType: 'Nhanh', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Hoàng Văn E', phone: '0945678901', address: '33 Cộng Hòa', province: 'Tân Bình, TP.HCM' },
-    package: { weight: 1.0, description: 'Sách vở', value: 200000 },
-    codAmount: 0, shippingFee: 25000, paymentSide: 'sender',
-    note: '',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '14/05/2026 14:10', location: 'Hệ thống', done: true, active: true },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '—', location: '', done: false, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '—', location: '', done: false, active: false },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '—', location: '', done: false, active: false },
-    ],
-  },
-  '6': {
-    id: '6', trackingCode: 'PB001239', status: 'cancelled',
-    createdAt: '14/05/2026 13:00', updatedAt: '14/05/2026 13:30',
-    serviceType: 'Tiêu chuẩn', estimatedDelivery: '—',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Võ Thị F', phone: '0956789012', address: '77 Nguyễn Thái Sơn', province: 'Phú Nhuận, TP.HCM' },
-    package: { weight: 0.8, description: 'Thực phẩm', value: 500000 },
-    codAmount: 320000, shippingFee: 22000, paymentSide: 'receiver',
-    note: '',
-    timeline: [
-      { status: 'pending', label: 'Đơn hàng được tạo', time: '14/05/2026 13:00', location: 'Hệ thống', done: true, active: false },
-      { status: 'cancelled', label: 'Đơn hàng đã bị huỷ', time: '14/05/2026 13:30', location: 'Hệ thống', done: true, active: true },
-    ],
-  },
-  '7': {
-    id: '7', trackingCode: 'PB001240', status: 'in_transit',
-    createdAt: '14/05/2026 10:00', updatedAt: '14/05/2026 18:00',
-    serviceType: 'Nhanh', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Đặng Văn G', phone: '0967890123', address: '12 Nguyễn Văn Linh', province: 'Quận 7, TP.HCM' },
-    package: { weight: 5.0, description: 'Máy móc phụ tùng', value: 3000000 },
-    codAmount: 800000, shippingFee: 55000, paymentSide: 'receiver',
-    note: 'Hàng nặng, cần 2 người bốc',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '14/05/2026 10:10', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '14/05/2026 12:00', location: 'Quận 1, TP.HCM', done: true, active: false },
-      { status: 'at_hub', label: 'Hàng đến kho tổng', time: '14/05/2026 15:00', location: 'Hub Thủ Đức', done: true, active: false },
-      { status: 'in_transit', label: 'Đang vận chuyển đến chi nhánh', time: '14/05/2026 18:00', location: 'Đang di chuyển', done: true, active: true },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '—', location: '', done: false, active: false },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '—', location: '', done: false, active: false },
-    ],
-  },
-  '8': {
-    id: '8', trackingCode: 'PB001241', status: 'out_for_delivery',
-    createdAt: '14/05/2026 09:00', updatedAt: '15/05/2026 08:30',
-    serviceType: 'Tiêu chuẩn', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Bùi Thị H', phone: '0978901234', address: '55 Ba Tháng Hai', province: 'Quận 10, TP.HCM' },
-    package: { weight: 1.2, description: 'Đồ gia dụng', value: 450000 },
-    codAmount: 0, shippingFee: 28000, paymentSide: 'sender',
-    note: '',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '14/05/2026 09:15', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '14/05/2026 11:30', location: 'Quận 1, TP.HCM', done: true, active: false },
-      { status: 'at_hub', label: 'Hàng đến bưu cục', time: '14/05/2026 14:00', location: 'Hub Q.1 - TP.HCM', done: true, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '15/05/2026 08:30', location: 'Quận 10, TP.HCM', done: true, active: true },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '—', location: '', done: false, active: false },
-    ],
-  },
-  '9': {
-    id: '9', trackingCode: 'PB001242', status: 'picked_up',
-    createdAt: '13/05/2026 16:00', updatedAt: '13/05/2026 18:00',
-    serviceType: 'Nhanh', estimatedDelivery: '15/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Ngô Văn I', phone: '0989012345', address: '99 Lê Thị Riêng', province: 'Quận 12, TP.HCM' },
-    package: { weight: 2.5, description: 'Quần áo thể thao', value: 600000 },
-    codAmount: 450000, shippingFee: 38000, paymentSide: 'receiver',
-    note: 'Giao buổi sáng',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '13/05/2026 16:10', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '13/05/2026 18:00', location: 'Quận 1, TP.HCM', done: true, active: true },
-      { status: 'at_hub', label: 'Hàng đến kho tổng', time: '—', location: '', done: false, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '—', location: '', done: false, active: false },
-      { status: 'delivered', label: 'Giao hàng thành công', time: '—', location: '', done: false, active: false },
-    ],
-  },
-  '10': {
-    id: '10', trackingCode: 'PB001243', status: 'failed',
-    createdAt: '13/05/2026 11:00', updatedAt: '13/05/2026 16:00',
-    serviceType: 'Tiêu chuẩn', estimatedDelivery: '13/05/2026',
-    sender: { name: 'Công ty ABC', phone: '0281234567', address: '123 Nguyễn Huệ, Q.1, TP.HCM' },
-    receiver: { name: 'Dương Thị K', phone: '0990123456', address: '24 Kha Vạn Cân', province: 'Thủ Đức, TP.HCM' },
-    package: { weight: 0.3, description: 'Tài liệu', value: 0 },
-    codAmount: 180000, shippingFee: 18000, paymentSide: 'receiver',
-    note: '',
-    timeline: [
-      { status: 'confirmed', label: 'Đơn hàng được xác nhận', time: '13/05/2026 11:10', location: 'Hệ thống', done: true, active: false },
-      { status: 'picked_up', label: 'Shipper đã lấy hàng', time: '13/05/2026 13:00', location: 'Quận 1, TP.HCM', done: true, active: false },
-      { status: 'out_for_delivery', label: 'Đang giao đến người nhận', time: '13/05/2026 15:00', location: 'Thủ Đức, TP.HCM', done: true, active: false },
-      { status: 'failed', label: 'Giao thất bại - Người nhận vắng', time: '13/05/2026 16:00', location: 'Thủ Đức, TP.HCM', done: true, active: true },
-    ],
-  },
-}
-
+// ---- Status config ----
 const STATUS_CONFIG: Record<string, { label: string; color: string; icon: React.ElementType }> = {
   pending:          { label: 'Chờ xác nhận',   color: 'bg-amber-100 text-amber-700',   icon: Clock },
   confirmed:        { label: 'Đã xác nhận',     color: 'bg-blue-100 text-blue-700',     icon: CheckCircle },
@@ -220,32 +23,33 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: React.
   at_hub:           { label: 'Tại bưu cục',     color: 'bg-purple-100 text-purple-700', icon: Package },
   sorting:          { label: 'Đang phân loại',  color: 'bg-yellow-100 text-yellow-700', icon: Package },
   out_for_delivery: { label: 'Đang giao',       color: 'bg-blue-100 text-blue-700',     icon: Truck },
-  delivering:       { label: 'Đang giao',       color: 'bg-blue-100 text-blue-700',     icon: Truck },
   delivered:        { label: 'Đã giao',         color: 'bg-green-100 text-green-700',   icon: CheckCircle },
   failed:           { label: 'Giao thất bại',   color: 'bg-red-100 text-red-700',       icon: XCircle },
-  returned:         { label: 'Hoàn hàng',  color: 'bg-rose-100 text-rose-700',    icon: RotateCcw },
-  cancelled:        { label: 'Đã huỷ',          color: 'bg-gray-100 text-gray-500',    icon: XCircle },
+  returned:         { label: 'Hoàn hàng',       color: 'bg-rose-100 text-rose-700',     icon: RotateCcw },
+  cancelled:        { label: 'Đã huỷ',          color: 'bg-gray-100 text-gray-500',     icon: XCircle },
 }
 
-// ── Màu dot + icon cho từng bước timeline ────────────────────────────
-const TIMELINE_DOT: Record<string, {
-  dot: string; icon: React.ElementType; iconColor: string; textColor: string
-}> = {
-  confirmed:        { dot: 'bg-blue-100 ring-2 ring-blue-200',        icon: CheckCircle, iconColor: 'text-blue-600',   textColor: 'text-blue-700'   },
+const TIMELINE_DOT: Record<string, { dot: string; icon: React.ElementType; iconColor: string; textColor: string }> = {
+  confirmed:        { dot: 'bg-blue-100 ring-2 ring-blue-200',         icon: CheckCircle, iconColor: 'text-blue-600',   textColor: 'text-blue-700'   },
   picked_up:        { dot: 'bg-indigo-500 shadow-md shadow-indigo-200',icon: Package,     iconColor: 'text-white',      textColor: 'text-indigo-700' },
   at_hub:           { dot: 'bg-purple-500 shadow-md shadow-purple-200',icon: Package,     iconColor: 'text-white',      textColor: 'text-purple-700' },
   sorting:          { dot: 'bg-yellow-400 shadow-md shadow-yellow-200',icon: Package,     iconColor: 'text-white',      textColor: 'text-yellow-700' },
   in_transit:       { dot: 'bg-purple-500 shadow-md shadow-purple-200',icon: Truck,       iconColor: 'text-white',      textColor: 'text-purple-700' },
   out_for_delivery: { dot: 'bg-blue-500 shadow-md shadow-blue-200',    icon: Truck,       iconColor: 'text-white',      textColor: 'text-blue-700'   },
-  delivering:       { dot: 'bg-blue-500 shadow-md shadow-blue-200',    icon: Truck,       iconColor: 'text-white',      textColor: 'text-blue-700'   },
   delivered:        { dot: 'bg-green-500 shadow-md shadow-green-200',  icon: CheckCircle, iconColor: 'text-white',      textColor: 'text-green-700'  },
   failed:           { dot: 'bg-red-500 shadow-md shadow-red-200',      icon: XCircle,     iconColor: 'text-white',      textColor: 'text-red-700'    },
   returned:         { dot: 'bg-rose-400 shadow-md shadow-rose-200',    icon: RotateCcw,   iconColor: 'text-white',      textColor: 'text-rose-700'   },
   cancelled:        { dot: 'bg-gray-400',                              icon: XCircle,     iconColor: 'text-white',      textColor: 'text-gray-500'   },
   default:          { dot: 'bg-blue-100 ring-2 ring-blue-200',         icon: CheckCircle, iconColor: 'text-blue-500',   textColor: 'text-gray-700'   },
 }
-// Bước chưa tới — dot rỗng viền xám
 const PENDING_DOT = { dot: 'bg-white border-2 border-gray-200', icon: Clock, iconColor: 'text-gray-300', textColor: 'text-gray-400' }
+
+function formatDateTime(iso: string) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return d.toLocaleDateString('vi-VN', { day: '2-digit', month: '2-digit', year: 'numeric' })
+    + ' ' + d.toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit' })
+}
 
 function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -259,9 +63,21 @@ function InfoRow({ label, children }: { label: string; children: React.ReactNode
 export default function OrderDetailPage() {
   const params = useParams()
   const router = useRouter()
-  const { success, info } = useToast()
+  const { success, error: showError } = useToast()
+  const orderId = params.id as string
 
-  const order = MOCK_ORDERS[params.id as string]
+  const [order, setOrder] = useState<Order | null>(null)
+  const [history, setHistory] = useState<OrderHistoryEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [cancelling, setCancelling] = useState(false)
+
+  useEffect(() => {
+    Promise.all([getOrder(orderId), getOrderHistory(orderId)])
+      .then(([o, h]) => { setOrder(o); setHistory(h) })
+      .catch(err => setLoadError(err instanceof Error ? err.message : 'Không thể tải đơn hàng'))
+      .finally(() => setLoading(false))
+  }, [orderId])
 
   const copyTracking = () => {
     if (!order) return
@@ -269,18 +85,40 @@ export default function OrderDetailPage() {
     success('Đã sao chép!', `Mã vận đơn ${order.trackingCode} đã được sao chép`)
   }
 
-  const handleCancelOrder = () => {
-    info('Đang xử lý...', 'Chức năng huỷ đơn sẽ được kết nối với API')
+  const handleCancelOrder = async () => {
+    if (!order) return
+    setCancelling(true)
+    try {
+      await cancelOrder(order.id)
+      setOrder(prev => prev ? { ...prev, status: 'cancelled' } : prev)
+      success('Đã huỷ đơn', `Đơn hàng ${order.trackingCode} đã được huỷ`)
+    } catch (err) {
+      showError('Huỷ thất bại', err instanceof Error ? err.message : 'Không thể huỷ đơn')
+    } finally {
+      setCancelling(false)
+    }
   }
 
-  if (!order) {
+  if (loading) {
+    return (
+      <>
+        <ToastContainer />
+        <div className="flex items-center justify-center py-32 text-gray-400">
+          <Loader2 size={24} className="animate-spin mr-2" />
+          <span className="text-sm">Đang tải thông tin đơn hàng...</span>
+        </div>
+      </>
+    )
+  }
+
+  if (loadError || !order) {
     return (
       <>
         <ToastContainer />
         <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
           <AlertCircle size={40} className="text-gray-300" />
           <h2 className="text-lg font-semibold text-gray-700">Không tìm thấy đơn hàng</h2>
-          <p className="text-sm text-gray-400">Mã đơn không tồn tại hoặc đã bị xoá</p>
+          <p className="text-sm text-gray-400">{loadError || 'Mã đơn không tồn tại hoặc đã bị xoá'}</p>
           <Link href="/orders"
             className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors">
             Về danh sách đơn
@@ -290,11 +128,28 @@ export default function OrderDetailPage() {
     )
   }
 
-  const statusCfg = STATUS_CONFIG[order.status] ?? STATUS_CONFIG['pending']
+  const statusCfg = STATUS_CONFIG[order.status as string] ?? STATUS_CONFIG['pending']
   const StatusIcon = statusCfg.icon
-  const totalCollect = order.paymentSide === 'receiver'
-    ? order.codAmount + order.shippingFee
-    : order.codAmount
+  const totalCollect = order.codAmount
+
+  // Build timeline from history; if empty, show single current-status entry
+  const timelineItems = history.length > 0
+    ? history.map((h, idx) => ({
+        status:   h.status as string,
+        label:    STATUS_CONFIG[h.status as string]?.label ?? String(h.status),
+        time:     formatDateTime(h.timestamp),
+        location: h.note || '',
+        done:     true,
+        active:   idx === history.length - 1,
+      }))
+    : [{
+        status:   order.status as string,
+        label:    statusCfg.label,
+        time:     formatDateTime(order.updatedAt),
+        location: '',
+        done:     true,
+        active:   true,
+      }]
 
   return (
     <>
@@ -317,22 +172,23 @@ export default function OrderDetailPage() {
         {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div className="flex items-center gap-3">
-            <button onClick={() => router.push('/orders')}
-              className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors">
+            <button type="button" onClick={() => router.push('/orders')}
+              className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors"
+              aria-label="Quay lại">
               <ArrowLeft size={16} />
             </button>
             <div>
               <div className="flex items-center gap-2.5">
                 <h1 className="text-xl font-bold text-gray-900 font-mono">{order.trackingCode}</h1>
-                <button
-                  onClick={copyTracking}
+                <button type="button" onClick={copyTracking}
                   className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-                  title="Sao chép mã vận đơn"
-                >
+                  aria-label="Sao chép mã vận đơn">
                   <Copy size={14} />
                 </button>
               </div>
-              <p className="text-xs text-gray-400 mt-0.5">Tạo lúc {order.createdAt} · {order.serviceType}</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                Tạo lúc {formatDateTime(order.createdAt)}
+              </p>
             </div>
           </div>
           <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold ${statusCfg.color}`}>
@@ -351,13 +207,13 @@ export default function OrderDetailPage() {
               <div className="flex items-center gap-2.5 px-5 py-4 border-b border-gray-100 bg-gray-50">
                 <Truck size={16} className="text-blue-600" />
                 <h2 className="text-sm font-semibold text-gray-800">Hành trình đơn hàng</h2>
-                <span className="ml-auto text-xs text-gray-400">Cập nhật: {order.updatedAt}</span>
+                <span className="ml-auto text-xs text-gray-400">Cập nhật: {formatDateTime(order.updatedAt)}</span>
               </div>
               <div className="p-5">
                 <div className="relative">
                   <div className="absolute left-[15px] top-5 bottom-5 w-px bg-gray-100" />
                   <div className="flex flex-col gap-0">
-                    {order.timeline.map((event, idx) => {
+                    {timelineItems.map((event, idx) => {
                       const dotCfg = event.done
                         ? (TIMELINE_DOT[event.status] ?? TIMELINE_DOT['default'])
                         : PENDING_DOT
@@ -372,7 +228,7 @@ export default function OrderDetailPage() {
                               {event.label}
                             </p>
                             <div className="flex items-center gap-3 mt-0.5">
-                              {event.time !== '—' && (
+                              {event.time && event.time !== '—' && (
                                 <span className="text-xs text-gray-400">{event.time}</span>
                               )}
                               {event.location && (
@@ -399,15 +255,27 @@ export default function OrderDetailPage() {
               <div className="p-5 grid grid-cols-1 sm:grid-cols-2 gap-x-8">
                 <div>
                   <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">Người nhận</p>
-                  <InfoRow label="Họ tên"><span className="flex items-center gap-1.5"><User size={13} className="text-gray-400" />{order.receiver.name}</span></InfoRow>
-                  <InfoRow label="Điện thoại"><span className="flex items-center gap-1.5"><Phone size={13} className="text-gray-400" />{order.receiver.phone}</span></InfoRow>
-                  <InfoRow label="Địa chỉ"><span className="flex items-center gap-1.5"><MapPin size={13} className="text-gray-400" />{order.receiver.address}, {order.receiver.province}</span></InfoRow>
+                  <InfoRow label="Họ tên">
+                    <span className="flex items-center gap-1.5"><User size={13} className="text-gray-400" />{order.receiverName}</span>
+                  </InfoRow>
+                  <InfoRow label="Điện thoại">
+                    <span className="flex items-center gap-1.5"><Phone size={13} className="text-gray-400" />{order.receiverPhone}</span>
+                  </InfoRow>
+                  <InfoRow label="Địa chỉ">
+                    <span className="flex items-center gap-1.5"><MapPin size={13} className="text-gray-400" />{order.receiverAddress}</span>
+                  </InfoRow>
                 </div>
                 <div className="mt-5 sm:mt-0">
                   <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">Người gửi</p>
-                  <InfoRow label="Tên"><span className="flex items-center gap-1.5"><User size={13} className="text-gray-400" />{order.sender.name}</span></InfoRow>
-                  <InfoRow label="Điện thoại"><span className="flex items-center gap-1.5"><Phone size={13} className="text-gray-400" />{order.sender.phone}</span></InfoRow>
-                  <InfoRow label="Địa chỉ"><span className="flex items-center gap-1.5"><MapPin size={13} className="text-gray-400" />{order.sender.address}</span></InfoRow>
+                  <InfoRow label="Tên">
+                    <span className="flex items-center gap-1.5"><User size={13} className="text-gray-400" />{order.senderName}</span>
+                  </InfoRow>
+                  <InfoRow label="Điện thoại">
+                    <span className="flex items-center gap-1.5"><Phone size={13} className="text-gray-400" />{order.senderPhone}</span>
+                  </InfoRow>
+                  <InfoRow label="Bưu cục gửi">
+                    <span className="flex items-center gap-1.5"><MapPin size={13} className="text-gray-400" />{order.senderAddress}</span>
+                  </InfoRow>
                 </div>
               </div>
             </div>
@@ -419,9 +287,8 @@ export default function OrderDetailPage() {
                 <h2 className="text-sm font-semibold text-gray-800">Thông tin hàng hoá</h2>
               </div>
               <div className="p-5">
-                <InfoRow label="Mô tả">{order.package.description || '—'}</InfoRow>
-                <InfoRow label="Khối lượng">{order.package.weight} kg</InfoRow>
-                <InfoRow label="Giá trị hàng">{order.package.value > 0 ? order.package.value.toLocaleString('vi-VN') + ' đ' : '—'}</InfoRow>
+                {order.dimensions && <InfoRow label="Kích thước">{order.dimensions}</InfoRow>}
+                <InfoRow label="Khối lượng">{order.weight} kg</InfoRow>
                 {order.note && <InfoRow label="Ghi chú">{order.note}</InfoRow>}
               </div>
             </div>
@@ -447,10 +314,6 @@ export default function OrderDetailPage() {
                     {order.codAmount > 0 ? order.codAmount.toLocaleString('vi-VN') + ' đ' : '—'}
                   </span>
                 </div>
-                <div className="flex justify-between text-gray-600">
-                  <span>Người trả phí</span>
-                  <span className="font-medium text-gray-900">{order.paymentSide === 'receiver' ? 'Người nhận' : 'Người gửi'}</span>
-                </div>
                 <div className="border-t border-dashed border-gray-200 pt-3 mt-1 flex justify-between">
                   <span className="text-xs text-gray-500">Tổng thu khi giao</span>
                   <span className="font-bold text-lg text-blue-600">{totalCollect.toLocaleString('vi-VN')} đ</span>
@@ -472,22 +335,20 @@ export default function OrderDetailPage() {
                 </Link>
                 {(order.status === 'pending' || order.status === 'confirmed') && (
                   <button
+                    type="button"
                     onClick={handleCancelOrder}
-                    className="flex items-center justify-center gap-2 w-full py-2.5 border border-red-200 rounded-lg text-sm text-red-600 font-medium hover:bg-red-50 transition-colors"
+                    disabled={cancelling}
+                    className="flex items-center justify-center gap-2 w-full py-2.5 border border-red-200 rounded-lg text-sm text-red-600 font-medium hover:bg-red-50 transition-colors disabled:opacity-50"
                   >
-                    <XCircle size={14} /> Huỷ đơn hàng
+                    {cancelling
+                      ? <><Loader2 size={14} className="animate-spin" /> Đang huỷ...</>
+                      : <><XCircle size={14} /> Huỷ đơn hàng</>
+                    }
                   </button>
                 )}
               </div>
             </div>
 
-            {/* Giao hàng dự kiến */}
-            {order.estimatedDelivery !== '—' && (
-              <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 text-center">
-                <p className="text-xs text-blue-500 font-medium">Dự kiến giao hàng</p>
-                <p className="text-lg font-bold text-blue-700 mt-1">{order.estimatedDelivery}</p>
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/apps/sender-web/app/(dashboard)/orders/new/page.tsx
+++ b/apps/sender-web/app/(dashboard)/orders/new/page.tsx
@@ -5,10 +5,12 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import {
   Home, ChevronRight, Package, MapPin, Phone,
-  User, Weight, Banknote, FileText, ArrowLeft,
-  CheckCircle, AlertCircle, Truck
+  User, Banknote, FileText, ArrowLeft,
+  CheckCircle, AlertCircle, Truck, Loader2, Copy
 } from 'lucide-react'
 import LocationSelector from '@/components/ui/LocationSelector'
+import { createOrder, BRANCH_LIST } from '@picbox/utils'
+import { getCurrentUser } from '@/lib/auth-service'
 
 interface FormData {
   receiverName: string
@@ -27,34 +29,17 @@ interface FormData {
   paymentSide: 'sender' | 'receiver'
   note: string
   serviceType: 'standard' | 'express' | 'sameday'
+  destBranchId: string
 }
 
 const SERVICE_OPTIONS = [
-  {
-    id: 'standard',
-    label: 'Tiêu chuẩn',
-    time: '2–3 ngày',
-    price: '22.000 đ',
-    desc: 'Giao hàng trong 2–3 ngày làm việc',
-    icon: Package,
-  },
-  {
-    id: 'express',
-    label: 'Nhanh',
-    time: 'Hôm sau',
-    price: '35.000 đ',
-    desc: 'Giao hàng ngay hôm sau trước 12h',
-    icon: Truck,
-  },
-  {
-    id: 'sameday',
-    label: 'Trong ngày',
-    time: '4–6 tiếng',
-    price: '55.000 đ',
-    desc: 'Giao trong ngày, nội thành TP.HCM',
-    icon: CheckCircle,
-  },
+  { id: 'standard', label: 'Tiêu chuẩn', time: '2–3 ngày', price: '22.000 đ', fee: 22000, desc: 'Giao hàng trong 2–3 ngày làm việc', icon: Package },
+  { id: 'express',  label: 'Nhanh',       time: 'Hôm sau',  price: '35.000 đ', fee: 35000, desc: 'Giao hàng ngay hôm sau trước 12h',  icon: Truck },
+  { id: 'sameday',  label: 'Trong ngày',  time: '4–6 tiếng',price: '55.000 đ', fee: 55000, desc: 'Giao trong ngày, nội thành TP.HCM', icon: CheckCircle },
 ]
+
+// Sender's default origin branch — in production this comes from user profile / settings
+const ORIGIN_BRANCH = { id: 'HCM_01', name: 'Chi nhánh TP.HCM - Quận 1' }
 
 function Label({ children, required }: { children: React.ReactNode; required?: boolean }) {
   return (
@@ -76,11 +61,7 @@ function Input({ ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
   )
 }
 
-function SectionCard({ title, icon: Icon, children }: {
-  title: string
-  icon: React.ElementType
-  children: React.ReactNode
-}) {
+function SectionCard({ title, icon: Icon, children }: { title: string; icon: React.ElementType; children: React.ReactNode }) {
   return (
     <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
       <div className="flex items-center gap-2.5 px-5 py-4 border-b border-gray-100 bg-gray-50">
@@ -95,87 +76,136 @@ function SectionCard({ title, icon: Icon, children }: {
 export default function NewOrderPage() {
   const router = useRouter()
   const [form, setForm] = useState<FormData>({
-    receiverName: '',
-    receiverPhone: '',
-    receiverAddress: '',
-    receiverProvince: '',
-    receiverDistrict: '',
-    receiverWard: '',
-    packageWeight: '',
-    packageWidth: '',
-    packageLength: '',
-    packageHeight: '',
-    packageDescription: '',
-    packageValue: '',
-    codAmount: '',
-    paymentSide: 'receiver',
-    note: '',
-    serviceType: 'standard',
+    receiverName: '', receiverPhone: '', receiverAddress: '',
+    receiverProvince: '', receiverDistrict: '', receiverWard: '',
+    packageWeight: '', packageWidth: '', packageLength: '', packageHeight: '',
+    packageDescription: '', packageValue: '', codAmount: '',
+    paymentSide: 'receiver', note: '', serviceType: 'standard',
+    destBranchId: BRANCH_LIST[0]?.id ?? '',
   })
 
   const [receiverLocation, setReceiverLocation] = useState({
-    provinceCode: '',
-    provinceName: '',
-    districtCode: '',
-    districtName: '',
-    ward: '',
-    address: ''
+    provinceCode: '', provinceName: '', districtCode: '', districtName: '', ward: '', address: ''
   })
 
-  const [errors, setErrors] = useState<Partial<Record<keyof FormData, string>>>({})
-  const [submitted, setSubmitted] = useState(false)
+  const [errors, setErrors] = useState<Partial<Record<keyof FormData | 'general', string>>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [createdTrackingCode, setCreatedTrackingCode] = useState<string | null>(null)
 
   useEffect(() => {
     setForm(prev => ({
       ...prev,
       receiverProvince: receiverLocation.provinceName,
       receiverDistrict: receiverLocation.districtName,
-      receiverWard: receiverLocation.ward,
-      receiverAddress: receiverLocation.address 
+      receiverWard:     receiverLocation.ward,
+      receiverAddress:  receiverLocation.address,
     }))
   }, [receiverLocation])
 
-  const set = (field: keyof FormData) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-    setForm(f => ({ ...f, [field]: e.target.value }))
-    setErrors(er => ({ ...er, [field]: '' }))
-  }
+  const set = (field: keyof FormData) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+      setForm(f => ({ ...f, [field]: e.target.value }))
+      setErrors(er => ({ ...er, [field]: '' }))
+    }
 
   const validate = () => {
-    const e: Partial<Record<keyof FormData, string>> = {}
-    if (!form.receiverName.trim()) e.receiverName = 'Vui lòng nhập tên người nhận'
-    if (!form.receiverPhone.trim()) e.receiverPhone = 'Vui lòng nhập số điện thoại'
-    if (!form.receiverProvince) e.receiverProvince = 'Vui lòng chọn Tỉnh/Thành'
-    if (!form.receiverDistrict) e.receiverDistrict = 'Vui lòng chọn Quận/Huyện'
-    if (!form.receiverAddress.trim()) e.receiverAddress = 'Vui lòng nhập địa chỉ cụ thể'
-    if (!form.packageWeight.trim()) e.packageWeight = 'Vui lòng nhập khối lượng'
+    const e: Partial<Record<keyof FormData | 'general', string>> = {}
+    if (!form.receiverName.trim())    e.receiverName    = 'Vui lòng nhập tên người nhận'
+    if (!form.receiverPhone.trim())   e.receiverPhone   = 'Vui lòng nhập số điện thoại'
+    if (!form.receiverProvince)       e.receiverProvince = 'Vui lòng chọn Tỉnh/Thành'
+    if (!form.receiverDistrict)       e.receiverDistrict = 'Vui lòng chọn Quận/Huyện'
+    if (!form.receiverAddress.trim()) e.receiverAddress  = 'Vui lòng nhập địa chỉ cụ thể'
+    if (!form.packageWeight.trim())   e.packageWeight    = 'Vui lòng nhập khối lượng'
+    if (!form.destBranchId)           e.destBranchId     = 'Vui lòng chọn chi nhánh đích'
     return e
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const e = validate()
     if (Object.keys(e).length > 0) {
       setErrors(e)
       window.scrollTo({ top: 0, behavior: 'smooth' })
       return
     }
-    setSubmitted(true)
-    setTimeout(() => {
-      router.push('/orders')
-    }, 2000)
+
+    setSubmitting(true)
+    setErrors({})
+
+    try {
+      const currentUser = getCurrentUser()
+      const destBranch = BRANCH_LIST.find(b => b.id === form.destBranchId) ?? BRANCH_LIST[0]
+      const svcFee = SERVICE_OPTIONS.find(s => s.id === form.serviceType)?.fee ?? 22000
+      const cod = Number(form.codAmount.replace(/\D/g, '')) || 0
+
+      const order = await createOrder({
+        senderName:      currentUser?.name ?? 'Người gửi',
+        senderPhone:     '',
+        receiverName:    form.receiverName.trim(),
+        receiverPhone:   form.receiverPhone.trim(),
+        receiverAddress: [form.receiverAddress, form.receiverWard, form.receiverDistrict, form.receiverProvince]
+                           .filter(Boolean).join(', '),
+        originBranchId:   ORIGIN_BRANCH.id,
+        originBranchName: ORIGIN_BRANCH.name,
+        destBranchId:     destBranch.id,
+        destBranchName:   destBranch.name,
+        weight:  parseFloat(form.packageWeight) || 0,
+        width:   parseFloat(form.packageWidth)  || undefined,
+        height:  parseFloat(form.packageHeight) || undefined,
+        length:  parseFloat(form.packageLength) || undefined,
+        fee:     svcFee,
+        codAmount: cod || undefined,
+        note:    form.note.trim() || undefined,
+        pickupMethod: 'PICKUP_AT_DOOR',
+      })
+
+      setCreatedTrackingCode(order.trackingCode)
+    } catch (err) {
+      setErrors({ general: err instanceof Error ? err.message : 'Tạo đơn thất bại, vui lòng thử lại' })
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    } finally {
+      setSubmitting(false)
+    }
   }
 
-  const shippingFee = form.serviceType === 'standard' ? 22000 : form.serviceType === 'express' ? 35000 : 55000
-  const codAmount = Number(form.codAmount.replace(/\D/g, '')) || 0
+  const shippingFee = SERVICE_OPTIONS.find(s => s.id === form.serviceType)?.fee ?? 22000
+  const codAmount   = Number(form.codAmount.replace(/\D/g, '')) || 0
   const totalCollect = form.paymentSide === 'receiver' ? codAmount + shippingFee : codAmount
 
-  if (submitted) {
+  if (createdTrackingCode) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
         <div className="w-16 h-16 rounded-full bg-green-50 flex items-center justify-center">
           <CheckCircle size={32} className="text-green-500" />
         </div>
         <h2 className="text-lg font-bold text-gray-900">Tạo đơn thành công!</h2>
-        <p className="text-sm text-gray-500">Đơn hàng đang được xử lý...</p>
+        <div className="flex items-center gap-2 bg-gray-100 px-4 py-2 rounded-lg">
+          <span className="font-mono text-blue-600 font-bold text-lg">{createdTrackingCode}</span>
+          <button
+            type="button"
+            aria-label="Sao chép mã vận đơn"
+            onClick={() => navigator.clipboard.writeText(createdTrackingCode)}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            <Copy size={15} />
+          </button>
+        </div>
+        <p className="text-sm text-gray-500">Mã vận đơn đã được sao chép</p>
+        <div className="flex gap-3 mt-2">
+          <button
+            type="button"
+            onClick={() => router.push(`/orders`)}
+            className="px-4 py-2 border border-gray-200 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
+          >
+            Về danh sách đơn
+          </button>
+          <button
+            type="button"
+            onClick={() => { setCreatedTrackingCode(null); setForm(f => ({ ...f, receiverName: '', receiverPhone: '', codAmount: '', note: '' })) }}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            Tạo đơn mới
+          </button>
+        </div>
       </div>
     )
   }
@@ -193,14 +223,23 @@ export default function NewOrderPage() {
       </nav>
 
       <div className="flex items-center gap-3">
-        <button onClick={() => router.back()} className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors">
+        <button type="button" onClick={() => router.back()} aria-label="Quay lại"
+          className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors">
           <ArrowLeft size={16} />
         </button>
         <h1 className="text-xl font-bold text-gray-900">Tạo đơn hàng mới</h1>
       </div>
 
+      {errors.general && (
+        <div className="flex items-start gap-2.5 p-3.5 bg-red-50 border border-red-100 rounded-xl text-sm text-red-700">
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          {errors.general}
+        </div>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         <div className="lg:col-span-2 flex flex-col gap-5">
+
           <SectionCard title="Thông tin người nhận" icon={User}>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="sm:col-span-2">
@@ -216,13 +255,29 @@ export default function NewOrderPage() {
               <div className="sm:col-span-2">
                 <LocationSelector value={receiverLocation} onChange={setReceiverLocation} />
                 {(errors.receiverProvince || errors.receiverDistrict || errors.receiverAddress) && (
-                   <p className="mt-1 text-xs text-red-500">Vui lòng hoàn tất địa chỉ nhận hàng</p>
+                  <p className="mt-1 text-xs text-red-500">Vui lòng hoàn tất địa chỉ nhận hàng</p>
                 )}
+              </div>
+              <div className="sm:col-span-2">
+                <Label required>Chi nhánh đích</Label>
+                <select
+                  aria-label="Chọn chi nhánh đích"
+                  value={form.destBranchId}
+                  onChange={set('destBranchId')}
+                  className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {BRANCH_LIST.map(b => (
+                    <option key={b.id} value={b.id}>{b.name}</option>
+                  ))}
+                </select>
+                {errors.destBranchId && <p className="mt-1 text-xs text-red-500">{errors.destBranchId}</p>}
+                <p className="mt-1 text-xs text-gray-400 flex items-center gap-1">
+                  <MapPin size={10} /> Bưu cục gửi: {ORIGIN_BRANCH.name}
+                </p>
               </div>
             </div>
           </SectionCard>
 
-          {/* Phần hàng hóa đã được khôi phục đầy đủ */}
           <SectionCard title="Thông tin hàng hoá" icon={Package}>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
               <div className="col-span-2">
@@ -243,7 +298,7 @@ export default function NewOrderPage() {
                   rows={2}
                   placeholder="VD: Quần áo, giày dép, đồ điện tử..."
                   value={form.packageDescription}
-                  onChange={set('packageDescription') as any}
+                  onChange={set('packageDescription') as React.ChangeEventHandler<HTMLTextAreaElement>}
                   className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-900 focus:ring-2 focus:ring-blue-500 outline-none resize-none"
                 />
               </div>
@@ -271,8 +326,13 @@ export default function NewOrderPage() {
           </SectionCard>
 
           <SectionCard title="Ghi chú giao hàng" icon={FileText}>
-            <textarea rows={3} placeholder="Ghi chú cho shipper..." value={form.note} onChange={set('note') as any}
-              className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none resize-none" />
+            <textarea
+              rows={3}
+              placeholder="Ghi chú cho shipper..."
+              value={form.note}
+              onChange={set('note') as React.ChangeEventHandler<HTMLTextAreaElement>}
+              className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none resize-none"
+            />
           </SectionCard>
         </div>
 
@@ -285,9 +345,11 @@ export default function NewOrderPage() {
             <div className="p-4 flex flex-col gap-3">
               {SERVICE_OPTIONS.map(svc => (
                 <label key={svc.id} className={`flex items-start gap-3 p-3 border rounded-xl cursor-pointer transition-all ${form.serviceType === svc.id ? 'border-blue-400 bg-blue-50' : 'border-gray-200'}`}>
-                  <input type="radio" checked={form.serviceType === svc.id} onChange={() => setForm(f => ({ ...f, serviceType: svc.id as any }))} />
+                  <input type="radio" checked={form.serviceType === svc.id} onChange={() => setForm(f => ({ ...f, serviceType: svc.id as 'standard' | 'express' | 'sameday' }))} />
                   <div className="flex-1">
-                    <div className="flex justify-between font-semibold text-sm"><span>{svc.label}</span><span>{svc.price}</span></div>
+                    <div className="flex justify-between font-semibold text-sm">
+                      <span>{svc.label}</span><span>{svc.price}</span>
+                    </div>
                     <p className="text-xs text-gray-500">{svc.desc}</p>
                   </div>
                 </label>
@@ -303,8 +365,16 @@ export default function NewOrderPage() {
               <div className="border-t pt-3 flex justify-between font-bold text-blue-600 text-base">
                 <span>Tổng thu khi giao</span><span>{totalCollect.toLocaleString()} đ</span>
               </div>
-              <button onClick={handleSubmit} className="w-full bg-blue-600 text-white py-2.5 rounded-lg font-semibold hover:bg-blue-700 transition-colors">
-                Xác nhận tạo đơn
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="w-full bg-blue-600 text-white py-2.5 rounded-lg font-semibold hover:bg-blue-700 transition-colors disabled:opacity-60 flex items-center justify-center gap-2"
+              >
+                {submitting
+                  ? <><Loader2 size={16} className="animate-spin" /> Đang tạo đơn...</>
+                  : 'Xác nhận tạo đơn'
+                }
               </button>
             </div>
           </div>

--- a/apps/sender-web/app/(dashboard)/orders/page.tsx
+++ b/apps/sender-web/app/(dashboard)/orders/page.tsx
@@ -4,45 +4,13 @@ import { useState, useEffect } from 'react'
 import {
   Search, Filter, Plus, Package,
   ChevronLeft, ChevronRight, Eye,
-  ArrowUpDown, X, Home
+  ArrowUpDown, X, Home, Loader2, AlertCircle
 } from 'lucide-react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { getMyOrders } from '@picbox/utils'
+import type { Order, OrderStatus } from '@picbox/types'
 
-// ---- Types ----
-type OrderStatus =
-  | 'pending' | 'confirmed' | 'picked_up' | 'in_transit'
-  | 'at_hub' | 'sorting' | 'out_for_delivery'
-  | 'delivered' | 'failed' | 'returned' | 'cancelled'
-
-interface Order {
-  id: string
-  trackingCode: string
-  receiverName: string
-  receiverPhone: string
-  receiverAddress: string
-  weight: number
-  codAmount: number
-  shippingFee: number
-  status: OrderStatus
-  createdAt: string
-}
-
-// ---- Mock data ----
-const mockOrders: Order[] = [
-  { id: '1', trackingCode: 'PB001234', receiverName: 'Nguyễn Văn A', receiverPhone: '0901234567', receiverAddress: 'Quận 1, TP.HCM', weight: 1.5, codAmount: 250000, shippingFee: 30000, status: 'out_for_delivery' as OrderStatus, createdAt: '2026-05-15T08:00:00Z' },
-  { id: '2', trackingCode: 'PB001235', receiverName: 'Trần Thị B', receiverPhone: '0912345678', receiverAddress: 'Quận 3, TP.HCM', weight: 0.5, codAmount: 0, shippingFee: 20000, status: 'delivered', createdAt: '2026-05-15T07:30:00Z' },
-  { id: '3', trackingCode: 'PB001236', receiverName: 'Lê Văn C', receiverPhone: '0923456789', receiverAddress: 'Bình Thạnh, TP.HCM', weight: 2.0, codAmount: 500000, shippingFee: 35000, status: 'pending', createdAt: '2026-05-15T07:00:00Z' },
-  { id: '4', trackingCode: 'PB001237', receiverName: 'Phạm Thị D', receiverPhone: '0934567890', receiverAddress: 'Gò Vấp, TP.HCM', weight: 3.0, codAmount: 150000, shippingFee: 40000, status: 'returned', createdAt: '2026-05-14T15:00:00Z' },
-  { id: '5', trackingCode: 'PB001238', receiverName: 'Hoàng Văn E', receiverPhone: '0945678901', receiverAddress: 'Tân Bình, TP.HCM', weight: 1.0, codAmount: 0, shippingFee: 25000, status: 'confirmed', createdAt: '2026-05-14T14:00:00Z' },
-  { id: '6', trackingCode: 'PB001239', receiverName: 'Võ Thị F', receiverPhone: '0956789012', receiverAddress: 'Phú Nhuận, TP.HCM', weight: 0.8, codAmount: 320000, shippingFee: 22000, status: 'cancelled', createdAt: '2026-05-14T13:00:00Z' },
-  { id: '7', trackingCode: 'PB001240', receiverName: 'Đặng Văn G', receiverPhone: '0967890123', receiverAddress: 'Quận 7, TP.HCM', weight: 5.0, codAmount: 800000, shippingFee: 55000, status: 'in_transit', createdAt: '2026-05-14T10:00:00Z' },
-  { id: '8', trackingCode: 'PB001241', receiverName: 'Bùi Thị H', receiverPhone: '0978901234', receiverAddress: 'Quận 10, TP.HCM', weight: 1.2, codAmount: 0, shippingFee: 28000, status: 'out_for_delivery', createdAt: '2026-05-14T09:00:00Z' },
-  { id: '9', trackingCode: 'PB001242', receiverName: 'Ngô Văn I', receiverPhone: '0989012345', receiverAddress: 'Quận 12, TP.HCM', weight: 2.5, codAmount: 450000, shippingFee: 38000, status: 'picked_up', createdAt: '2026-05-13T16:00:00Z' },
-  { id: '10', trackingCode: 'PB001243', receiverName: 'Dương Thị K', receiverPhone: '0990123456', receiverAddress: 'Thủ Đức, TP.HCM', weight: 0.3, codAmount: 180000, shippingFee: 18000, status: 'failed', createdAt: '2026-05-13T11:00:00Z' },
-]
-
-// ---- Status config (TikTok Shop Style) ----
+// ---- Status config ----
 const STATUS_CONFIG: Record<string, { label: string; color: string; dot: string }> = {
   pending:          { label: 'Chờ xác nhận',   color: 'bg-gray-100 text-gray-500',     dot: 'bg-gray-400' },
   confirmed:        { label: 'Đã xác nhận',     color: 'bg-blue-50 text-blue-600',      dot: 'bg-blue-500' },
@@ -51,7 +19,6 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; dot: string 
   at_hub:           { label: 'Tại bưu cục',     color: 'bg-orange-50 text-orange-600',  dot: 'bg-orange-400' },
   sorting:          { label: 'Đang phân loại',  color: 'bg-orange-50 text-orange-600',  dot: 'bg-orange-400' },
   out_for_delivery: { label: 'Đang giao',       color: 'bg-cyan-50 text-cyan-600',      dot: 'bg-cyan-500' },
-  delivering:       { label: 'Đang giao',       color: 'bg-cyan-50 text-cyan-600',      dot: 'bg-cyan-500' },
   delivered:        { label: 'Đã giao',         color: 'bg-green-50 text-green-600',    dot: 'bg-green-500' },
   failed:           { label: 'Giao thất bại',   color: 'bg-red-50 text-red-500',        dot: 'bg-red-400' },
   returned:         { label: 'Hoàn hàng',       color: 'bg-amber-50 text-amber-600',    dot: 'bg-amber-400' },
@@ -82,24 +49,34 @@ function formatCurrency(amount: number) {
 }
 
 export default function OrdersPage() {
-  const router = useRouter()
+  const [orders, setOrders] = useState<Order[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
   const [search, setSearch] = useState('')
-  const [statusFilter, setStatusFilter] = useState('all')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
   const [page, setPage] = useState(1)
   const [sortDir, setSortDir] = useState<'desc' | 'asc'>('desc')
   const [showFilter, setShowFilter] = useState(false)
   const [dateFrom, setDateFrom] = useState('')
   const [dateTo, setDateTo] = useState('')
 
+  useEffect(() => {
+    getMyOrders(0, 100)
+      .then(res => setOrders(res.orders))
+      .catch(err => setError(err instanceof Error ? err.message : 'Không thể tải đơn hàng'))
+      .finally(() => setLoading(false))
+  }, [])
+
   useEffect(() => { setPage(1) }, [search, statusFilter, dateFrom, dateTo])
 
-  const filtered = mockOrders
+  const filtered = orders
     .filter(o => {
       const matchSearch =
         o.trackingCode.toLowerCase().includes(search.toLowerCase()) ||
         o.receiverName.toLowerCase().includes(search.toLowerCase()) ||
         o.receiverPhone.includes(search)
-      const matchStatus = statusFilter === 'all' || o.status === statusFilter
+      const matchStatus = statusFilter === 'all' || (o.status as string) === statusFilter
       const matchDateFrom = !dateFrom || new Date(o.createdAt) >= new Date(dateFrom)
       const matchDateTo = !dateTo || new Date(o.createdAt) <= new Date(dateTo + 'T23:59:59Z')
       return matchSearch && matchStatus && matchDateFrom && matchDateTo
@@ -111,7 +88,6 @@ export default function OrdersPage() {
 
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE)
   const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
-
   const hasActiveFilter = statusFilter !== 'all' || dateFrom || dateTo
 
   const resetFilters = () => {
@@ -119,6 +95,31 @@ export default function OrdersPage() {
     setDateFrom('')
     setDateTo('')
     setPage(1)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-32 text-gray-400">
+        <Loader2 size={24} className="animate-spin mr-2" />
+        <span className="text-sm">Đang tải đơn hàng...</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 text-red-500 gap-2">
+        <AlertCircle size={32} />
+        <p className="text-sm font-medium">{error}</p>
+        <button
+          type="button"
+          onClick={() => { setError(''); setLoading(true); getMyOrders(0, 100).then(r => setOrders(r.orders)).catch(e => setError(e.message)).finally(() => setLoading(false)) }}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          Thử lại
+        </button>
+      </div>
+    )
   }
 
   return (
@@ -176,9 +177,7 @@ export default function OrdersPage() {
             <Filter size={14} />
             Lọc
             {hasActiveFilter && (
-              <span className="w-4 h-4 bg-blue-600 text-white rounded-full text-[10px] flex items-center justify-center font-bold">
-                !
-              </span>
+              <span className="w-4 h-4 bg-blue-600 text-white rounded-full text-[10px] flex items-center justify-center font-bold">!</span>
             )}
           </button>
 
@@ -236,7 +235,7 @@ export default function OrdersPage() {
           </div>
         )}
 
-        {/* Status tab */}
+        {/* Status tabs */}
         <div className="flex gap-0 border-b border-gray-200 overflow-x-auto">
           {STATUS_FILTERS.slice(0, 6).map(f => (
             <button
@@ -279,13 +278,11 @@ export default function OrdersPage() {
               </thead>
               <tbody className="divide-y divide-gray-50">
                 {paginated.map(order => {
-                  const status = STATUS_CONFIG[order.status] ?? { label: order.status, color: 'bg-gray-100 text-gray-500', dot: 'bg-gray-400' }
+                  const status = STATUS_CONFIG[order.status as string] ?? { label: order.status, color: 'bg-gray-100 text-gray-500', dot: 'bg-gray-400' }
                   return (
                     <tr key={order.id} className="hover:bg-gray-50 transition-colors">
                       <td className="px-4 py-3.5">
-                        <span className="font-mono text-sm font-semibold text-blue-600">
-                          {order.trackingCode}
-                        </span>
+                        <span className="font-mono text-sm font-semibold text-blue-600">{order.trackingCode}</span>
                       </td>
                       <td className="px-4 py-3.5">
                         <p className="text-sm font-medium text-gray-900">{order.receiverName}</p>
@@ -303,7 +300,6 @@ export default function OrdersPage() {
                         <span className="text-sm text-gray-700">{formatCurrency(order.shippingFee)}</span>
                       </td>
                       <td className="px-4 py-3.5">
-                        {/* New Status Badge Design */}
                         <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${status.color}`}>
                           <span className={`w-1.5 h-1.5 rounded-full ${status.dot}`} />
                           {status.label}
@@ -326,7 +322,6 @@ export default function OrdersPage() {
           </div>
         )}
 
-        {/* Pagination */}
         {filtered.length > PAGE_SIZE && (
           <div className="flex items-center justify-between px-4 py-3 border-t border-gray-100">
             <span className="text-xs text-gray-500">
@@ -334,6 +329,8 @@ export default function OrdersPage() {
             </span>
             <div className="flex items-center gap-1">
               <button
+                type="button"
+                aria-label="Trang trước"
                 onClick={() => setPage(p => Math.max(1, p - 1))}
                 disabled={page === 1}
                 className="p-1.5 rounded-lg border border-gray-200 text-gray-500 hover:border-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
@@ -345,15 +342,15 @@ export default function OrdersPage() {
                   key={p}
                   onClick={() => setPage(p)}
                   className={`w-8 h-8 rounded-lg text-xs font-medium transition-colors ${
-                    p === page
-                      ? 'bg-blue-600 text-white'
-                      : 'border border-gray-200 text-gray-600 hover:border-gray-300'
+                    p === page ? 'bg-blue-600 text-white' : 'border border-gray-200 text-gray-600 hover:border-gray-300'
                   }`}
                 >
                   {p}
                 </button>
               ))}
               <button
+                type="button"
+                aria-label="Trang sau"
                 onClick={() => setPage(p => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
                 className="p-1.5 rounded-lg border border-gray-200 text-gray-500 hover:border-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"


### PR DESCRIPTION
- Add order-api.ts: createOrder, getMyOrders, getOrder, cancelOrder,
  getOrderHistory with backend status mapping (15→11 statuses)
- Replace mock orders in sender-web orders list, detail, and new order pages
- Add branch selector to new order form (hardcoded list, pending hub-service)
- Show real tracking code on successful order creation
- Wire cancel order button to DELETE /order/orders/{id}