### PR TITLE
feat(frontend): integrate real tracking API replacing mock data

### DIFF
--- a/apps/sender-web/app/tracking/[code]/page.tsx
+++ b/apps/sender-web/app/tracking/[code]/page.tsx
@@ -1,33 +1,32 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useEffect } from 'react'
+import { useRouter, useParams } from 'next/navigation'
 import Link from 'next/link'
 import {
   Search, Package, Truck, CheckCircle,
   XCircle, RotateCcw, Clock, MapPin,
-  Phone, User, ChevronRight, ArrowLeft
+  Phone, User, ArrowLeft, Loader2, AlertCircle
 } from 'lucide-react'
-import { getAllOrders, type OrderDetail } from '@/lib/mock-orders'
+import { getOrderByTracking, getOrderHistory } from '@picbox/utils'
+import type { OrderHistoryEvent } from '@picbox/utils'
+import type { Order } from '@picbox/types'
 
 // ── Status config ────────────────────────────────────────────────────
 const STATUS_CFG: Record<string, {
-  label: string
-  color: string
-  bg: string
-  icon: React.ElementType
-  desc: string
+  label: string; color: string; bg: string; icon: React.ElementType; desc: string
 }> = {
-  pending:          { label: 'Chờ xác nhận',   color: 'text-amber-700',  bg: 'bg-amber-50 border-amber-200',   icon: Clock,        desc: 'Đơn hàng đang chờ xác nhận từ hệ thống' },
-  confirmed:        { label: 'Đã xác nhận',     color: 'text-blue-700',   bg: 'bg-blue-50 border-blue-200',     icon: CheckCircle,  desc: 'Đơn hàng đã được xác nhận, đang chờ lấy hàng' },
-  picked_up:        { label: 'Đã lấy hàng',     color: 'text-indigo-700', bg: 'bg-indigo-50 border-indigo-200', icon: Package,      desc: 'Shipper đã lấy hàng thành công' },
-  in_transit:       { label: 'Đang vận chuyển', color: 'text-purple-700', bg: 'bg-purple-50 border-purple-200', icon: Truck,        desc: 'Hàng đang trên đường vận chuyển' },
-  at_hub:           { label: 'Tại bưu cục',     color: 'text-purple-700', bg: 'bg-purple-50 border-purple-200', icon: Package,      desc: 'Hàng đang ở bưu cục, chuẩn bị phát' },
-  out_for_delivery: { label: 'Đang giao',       color: 'text-blue-700',   bg: 'bg-blue-50 border-blue-200',     icon: Truck,        desc: 'Shipper đang trên đường giao đến bạn' },
-  delivered:        { label: 'Đã giao',         color: 'text-green-700',  bg: 'bg-green-50 border-green-200',   icon: CheckCircle,  desc: 'Giao hàng thành công' },
-  failed:           { label: 'Giao thất bại',   color: 'text-red-700',    bg: 'bg-red-50 border-red-200',       icon: XCircle,      desc: 'Không giao được hàng, vui lòng liên hệ shipper' },
-  returned:         { label: 'Hoàn hàng',       color: 'text-rose-700',   bg: 'bg-rose-50 border-rose-200',     icon: RotateCcw,    desc: 'Hàng đang được hoàn về người gửi' },
-  cancelled:        { label: 'Đã huỷ',          color: 'text-gray-600',   bg: 'bg-gray-50 border-gray-200',     icon: XCircle,      desc: 'Đơn hàng đã bị huỷ' },
+  pending:          { label: 'Chờ xác nhận',   color: 'text-amber-700',  bg: 'bg-amber-50 border-amber-200',   icon: Clock,       desc: 'Đơn hàng đang chờ xác nhận từ hệ thống' },
+  confirmed:        { label: 'Đã xác nhận',     color: 'text-blue-700',   bg: 'bg-blue-50 border-blue-200',     icon: CheckCircle, desc: 'Đơn hàng đã được xác nhận, đang chờ lấy hàng' },
+  picked_up:        { label: 'Đã lấy hàng',     color: 'text-indigo-700', bg: 'bg-indigo-50 border-indigo-200', icon: Package,     desc: 'Shipper đã lấy hàng thành công' },
+  in_transit:       { label: 'Đang vận chuyển', color: 'text-purple-700', bg: 'bg-purple-50 border-purple-200', icon: Truck,       desc: 'Hàng đang trên đường vận chuyển' },
+  at_hub:           { label: 'Tại bưu cục',     color: 'text-purple-700', bg: 'bg-purple-50 border-purple-200', icon: Package,     desc: 'Hàng đang ở bưu cục, chuẩn bị phát' },
+  sorting:          { label: 'Đang phân loại',  color: 'text-orange-700', bg: 'bg-orange-50 border-orange-200', icon: Package,     desc: 'Hàng đang được phân loại tại bưu cục' },
+  out_for_delivery: { label: 'Đang giao',       color: 'text-blue-700',   bg: 'bg-blue-50 border-blue-200',     icon: Truck,       desc: 'Shipper đang trên đường giao đến bạn' },
+  delivered:        { label: 'Đã giao',         color: 'text-green-700',  bg: 'bg-green-50 border-green-200',   icon: CheckCircle, desc: 'Giao hàng thành công' },
+  failed:           { label: 'Giao thất bại',   color: 'text-red-700',    bg: 'bg-red-50 border-red-200',       icon: XCircle,     desc: 'Không giao được hàng, vui lòng liên hệ shipper' },
+  returned:         { label: 'Hoàn hàng',       color: 'text-rose-700',   bg: 'bg-rose-50 border-rose-200',     icon: RotateCcw,   desc: 'Hàng đang được hoàn về người gửi' },
+  cancelled:        { label: 'Đã huỷ',          color: 'text-gray-600',   bg: 'bg-gray-50 border-gray-200',     icon: XCircle,     desc: 'Đơn hàng đã bị huỷ' },
 }
 
 // ── Timeline dot config ──────────────────────────────────────────────
@@ -35,6 +34,7 @@ const DOT_CFG: Record<string, { dot: string; icon: React.ElementType; iconColor:
   confirmed:        { dot: 'bg-blue-500',   icon: CheckCircle, iconColor: 'text-white' },
   picked_up:        { dot: 'bg-indigo-500', icon: Package,     iconColor: 'text-white' },
   at_hub:           { dot: 'bg-purple-500', icon: Package,     iconColor: 'text-white' },
+  sorting:          { dot: 'bg-orange-400', icon: Package,     iconColor: 'text-white' },
   in_transit:       { dot: 'bg-purple-500', icon: Truck,       iconColor: 'text-white' },
   out_for_delivery: { dot: 'bg-blue-600',   icon: Truck,       iconColor: 'text-white' },
   delivered:        { dot: 'bg-green-500',  icon: CheckCircle, iconColor: 'text-white' },
@@ -45,13 +45,13 @@ const DOT_CFG: Record<string, { dot: string; icon: React.ElementType; iconColor:
 }
 const PENDING_DOT = { dot: 'bg-white border-2 border-gray-200', icon: Clock, iconColor: 'text-gray-300' }
 
-// ── Progress bar steps ───────────────────────────────────────────────
+// ── Progress steps ───────────────────────────────────────────────────
 const PROGRESS_STEPS = [
-  { key: ['confirmed'], label: 'Xác nhận' },
-  { key: ['picked_up'], label: 'Lấy hàng' },
-  { key: ['at_hub', 'in_transit'], label: 'Vận chuyển' },
-  { key: ['out_for_delivery'], label: 'Đang giao' },
-  { key: ['delivered'], label: 'Hoàn thành' },
+  { key: ['confirmed'],                    label: 'Xác nhận' },
+  { key: ['picked_up'],                    label: 'Lấy hàng' },
+  { key: ['at_hub', 'in_transit', 'sorting'], label: 'Vận chuyển' },
+  { key: ['out_for_delivery'],             label: 'Đang giao' },
+  { key: ['delivered'],                    label: 'Hoàn thành' },
 ]
 
 function getProgressStep(status: string): number {
@@ -61,7 +61,49 @@ function getProgressStep(status: string): number {
   return 0
 }
 
-// ── Search bar component ─────────────────────────────────────────────
+function formatDateTime(iso: string) {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString('vi-VN', { day: '2-digit', month: '2-digit', year: 'numeric' })
+      + ' ' + d.toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return iso
+  }
+}
+
+// ── Timeline item shape ──────────────────────────────────────────────
+interface TimelineItem {
+  status: string
+  label: string
+  time: string
+  location?: string
+  done: boolean
+  active: boolean
+}
+
+function buildTimeline(order: Order, history: OrderHistoryEvent[]): TimelineItem[] {
+  if (history.length > 0) {
+    return history.map((h, idx) => ({
+      status:   h.status as string,
+      label:    STATUS_CFG[h.status as string]?.label ?? String(h.status),
+      time:     formatDateTime(h.timestamp),
+      location: h.note || '',
+      done:     true,
+      active:   idx === history.length - 1,
+    }))
+  }
+  return [{
+    status:   order.status as string,
+    label:    STATUS_CFG[order.status as string]?.label ?? String(order.status),
+    time:     formatDateTime(order.updatedAt),
+    location: '',
+    done:     true,
+    active:   true,
+  }]
+}
+
+// ── Search bar ───────────────────────────────────────────────────────
 function TrackingSearch({ initialCode = '' }: { initialCode?: string }) {
   const router = useRouter()
   const [code, setCode] = useState(initialCode)
@@ -96,14 +138,13 @@ function TrackingSearch({ initialCode = '' }: { initialCode?: string }) {
 }
 
 // ── Result card ──────────────────────────────────────────────────────
-function TrackingResult({ order }: { order: OrderDetail }) {
-  const cfg = STATUS_CFG[order.status] ?? STATUS_CFG['pending']
+function TrackingResult({ order, timeline }: { order: Order; timeline: TimelineItem[] }) {
+  const status = order.status as string
+  const cfg = STATUS_CFG[status] ?? STATUS_CFG['pending']
   const StatusIcon = cfg.icon
-  const progressStep = ['failed', 'returned', 'cancelled'].includes(order.status)
-    ? -1  // failed state — show differently
-    : getProgressStep(order.status)
-  const isFailed = ['failed', 'returned', 'cancelled'].includes(order.status)
-  const isDelivered = order.status === 'delivered'
+  const isFailed   = ['failed', 'returned', 'cancelled'].includes(status)
+  const isDelivered = status === 'delivered'
+  const progressStep = isFailed ? -1 : getProgressStep(status)
 
   return (
     <div className="flex flex-col gap-5 mt-6">
@@ -121,34 +162,29 @@ function TrackingResult({ order }: { order: OrderDetail }) {
             <span className="text-xs text-gray-400 font-mono">{order.trackingCode}</span>
           </div>
           <p className="text-sm text-gray-600 mt-0.5">{cfg.desc}</p>
-          <p className="text-xs text-gray-400 mt-1">Cập nhật: {order.updatedAt}</p>
+          <p className="text-xs text-gray-400 mt-1">Cập nhật: {formatDateTime(order.updatedAt)}</p>
         </div>
-        {isDelivered && (
-          <div className="text-3xl shrink-0">🎉</div>
-        )}
+        {isDelivered && <div className="text-3xl shrink-0">🎉</div>}
       </div>
 
-      {/* Progress bar — chỉ hiện khi không phải failed/cancelled */}
+      {/* Progress bar */}
       {!isFailed && (
         <div className="bg-white rounded-2xl border border-gray-200 p-5">
           <div className="flex items-center justify-between relative">
-            {/* Line */}
             <div className="absolute left-0 right-0 top-[18px] h-0.5 bg-gray-100 z-0" />
             <div
               className="absolute left-0 top-[18px] h-0.5 bg-blue-500 z-0 transition-all duration-700"
               style={{ width: `${(progressStep / (PROGRESS_STEPS.length - 1)) * 100}%` }}
             />
             {PROGRESS_STEPS.map((step, i) => {
-              const done = i <= progressStep
+              const done   = i <= progressStep
               const active = i === progressStep
               return (
                 <div key={step.label} className="flex flex-col items-center gap-2 relative z-10">
                   <div className={`w-9 h-9 rounded-full flex items-center justify-center transition-all ${
-                    active
-                      ? 'bg-blue-600 shadow-md shadow-blue-200 scale-110'
-                      : done
-                      ? 'bg-blue-100'
-                      : 'bg-gray-100'
+                    active ? 'bg-blue-600 shadow-md shadow-blue-200 scale-110'
+                    : done  ? 'bg-blue-100'
+                    : 'bg-gray-100'
                   }`}>
                     {done
                       ? <CheckCircle size={16} className={active ? 'text-white' : 'text-blue-500'} />
@@ -164,12 +200,10 @@ function TrackingResult({ order }: { order: OrderDetail }) {
               )
             })}
           </div>
-
-          {/* Estimated delivery */}
           <div className="mt-5 pt-4 border-t border-gray-100 flex items-center justify-between">
-            <span className="text-xs text-gray-500">Dự kiến giao hàng</span>
+            <span className="text-xs text-gray-500">Trạng thái hiện tại</span>
             <span className={`text-sm font-bold ${isDelivered ? 'text-green-600' : 'text-blue-700'}`}>
-              {isDelivered ? '✓ Đã giao thành công' : order.estimatedDelivery}
+              {isDelivered ? '✓ Đã giao thành công' : cfg.label}
             </span>
           </div>
         </div>
@@ -185,7 +219,7 @@ function TrackingResult({ order }: { order: OrderDetail }) {
           <div className="relative">
             <div className="absolute left-[15px] top-5 bottom-5 w-px bg-gray-100" />
             <div className="flex flex-col gap-0">
-              {order.timeline.map((event, idx) => {
+              {timeline.map((event, idx) => {
                 const dotCfg = event.done
                   ? (DOT_CFG[event.status] ?? DOT_CFG['default'])
                   : PENDING_DOT
@@ -204,7 +238,7 @@ function TrackingResult({ order }: { order: OrderDetail }) {
                         {event.label}
                       </p>
                       <div className="flex items-center gap-3 mt-0.5 flex-wrap">
-                        {event.time !== '—' && (
+                        {event.time && event.time !== '—' && (
                           <span className="text-xs text-gray-400">{event.time}</span>
                         )}
                         {event.location && (
@@ -222,7 +256,7 @@ function TrackingResult({ order }: { order: OrderDetail }) {
         </div>
       </div>
 
-      {/* Receiver info — hiển thị ẩn bớt thông tin nhạy cảm */}
+      {/* Receiver info — obfuscated */}
       <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
         <div className="flex items-center gap-2 px-5 py-4 border-b border-gray-100 bg-gray-50">
           <User size={15} className="text-blue-600" />
@@ -233,9 +267,8 @@ function TrackingResult({ order }: { order: OrderDetail }) {
             <User size={14} className="text-gray-400 mt-0.5 shrink-0" />
             <div>
               <p className="text-xs text-gray-400 mb-0.5">Người nhận</p>
-              {/* Ẩn bớt tên — chỉ hiện chữ đầu */}
               <p className="font-medium text-gray-900">
-                {order.receiver.name.charAt(0)}{'*'.repeat(Math.max(order.receiver.name.length - 2, 2))}{order.receiver.name.slice(-1)}
+                {order.receiverName.charAt(0)}{'*'.repeat(Math.max(order.receiverName.length - 2, 2))}{order.receiverName.slice(-1)}
               </p>
             </div>
           </div>
@@ -243,9 +276,8 @@ function TrackingResult({ order }: { order: OrderDetail }) {
             <Phone size={14} className="text-gray-400 mt-0.5 shrink-0" />
             <div>
               <p className="text-xs text-gray-400 mb-0.5">Số điện thoại</p>
-              {/* Ẩn giữa SĐT */}
               <p className="font-medium text-gray-900 font-mono">
-                {order.receiver.phone.slice(0, 3)}****{order.receiver.phone.slice(-3)}
+                {order.receiverPhone.slice(0, 3)}****{order.receiverPhone.slice(-3)}
               </p>
             </div>
           </div>
@@ -253,9 +285,7 @@ function TrackingResult({ order }: { order: OrderDetail }) {
             <MapPin size={14} className="text-gray-400 mt-0.5 shrink-0" />
             <div>
               <p className="text-xs text-gray-400 mb-0.5">Địa chỉ giao</p>
-              <p className="font-medium text-gray-900">
-                {order.receiver.address}, {order.receiver.province}
-              </p>
+              <p className="font-medium text-gray-900">{order.receiverAddress}</p>
             </div>
           </div>
         </div>
@@ -285,17 +315,35 @@ function NotFound({ code }: { code: string }) {
 }
 
 // ── Main page ────────────────────────────────────────────────────────
-export default function TrackingPage({ params }: { params: { code: string } }) {
-  const code = params.code?.toUpperCase() ?? ''
+export default function TrackingPage() {
+  const params = useParams()
+  const code = (params.code as string)?.toUpperCase() ?? ''
 
-  // Tìm đơn theo trackingCode (không phải id)
-  const allOrders = getAllOrders()
-  const order = allOrders.find(o => o.trackingCode === code)
+  const [order, setOrder]     = useState<Order | null>(null)
+  const [timeline, setTimeline] = useState<TimelineItem[]>([])
+  const [loading, setLoading] = useState(!!code)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    if (!code) return
+    setLoading(true)
+    setNotFound(false)
+    setOrder(null)
+
+    getOrderByTracking(code)
+      .then(async o => {
+        setOrder(o)
+        const history = await getOrderHistory(o.id).catch(() => [] as OrderHistoryEvent[])
+        setTimeline(buildTimeline(o, history))
+      })
+      .catch(() => setNotFound(true))
+      .finally(() => setLoading(false))
+  }, [code])
 
   return (
     <div className="min-h-screen bg-gray-50">
 
-      {/* Header public — không cần login */}
+      {/* Public header */}
       <header className="bg-white border-b border-gray-200 sticky top-0 z-30">
         <div className="max-w-2xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
           <Link href="/" className="font-bold text-blue-600 text-lg tracking-tight shrink-0">
@@ -314,7 +362,6 @@ export default function TrackingPage({ params }: { params: { code: string } }) {
       {/* Content */}
       <div className="max-w-2xl mx-auto px-4 py-6">
 
-        {/* Back link — chỉ hiện nếu có code */}
         {code && (
           <Link href="/tracking"
             className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-blue-600 transition-colors mb-2">
@@ -322,13 +369,12 @@ export default function TrackingPage({ params }: { params: { code: string } }) {
           </Link>
         )}
 
-        {/* Title */}
         <h1 className="text-xl font-bold text-gray-900 mb-1">Tra cứu đơn hàng</h1>
         <p className="text-sm text-gray-500 mb-5">
           Nhập mã vận đơn để theo dõi trạng thái giao hàng
         </p>
 
-        {/* Search (lớn — khi chưa có code) */}
+        {/* Search (large — shown when no code) */}
         {!code && (
           <div className="bg-white rounded-2xl border border-gray-200 p-6">
             <TrackingSearch />
@@ -338,10 +384,27 @@ export default function TrackingPage({ params }: { params: { code: string } }) {
           </div>
         )}
 
-        {/* Result */}
-        {code && (order
-          ? <TrackingResult order={order} />
-          : <NotFound code={code} />
+        {/* Loading */}
+        {code && loading && (
+          <div className="flex items-center justify-center py-20 text-gray-400 mt-6">
+            <Loader2 size={24} className="animate-spin mr-2" />
+            <span className="text-sm">Đang tra cứu...</span>
+          </div>
+        )}
+
+        {/* Result / Not found */}
+        {code && !loading && (
+          notFound
+            ? <NotFound code={code} />
+            : order && <TrackingResult order={order} timeline={timeline} />
+        )}
+
+        {/* API error fallback */}
+        {code && !loading && !notFound && !order && (
+          <div className="flex flex-col items-center justify-center py-14 gap-3 text-center mt-6">
+            <AlertCircle size={32} className="text-gray-300" />
+            <p className="text-sm text-gray-500">Không thể kết nối đến hệ thống. Vui lòng thử lại.</p>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
- tracking/[code]/page.tsx: replace getAllOrders() mock with
  getOrderByTracking() + getOrderHistory() real API calls
- Add loading, not-found, and error states
- Build timeline from OrderHistoryEvent[], fallback to current status
  if history endpoint returns empty
- Add sorting status to STATUS_CFG and progress steps