### PR TITLE
feat(admin-web): kết nối các trang quản lý với dữ liệu thật từ backend

### DIFF
--- a/apps/admin-web/src/app/hubs/page.tsx
+++ b/apps/admin-web/src/app/hubs/page.tsx
@@ -1,50 +1,33 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { AdminLayout } from "@/components/layout";
-import { MapPin, Package, Truck, Users, Plus, Activity } from "lucide-react";
+import { MapPin, Package, Users, Plus, Activity, Loader, Phone } from "lucide-react";
+import { getAllHubsAndBranches } from "@picbox/utils";
+import type { AdminHub } from "@picbox/utils";
 
-type HubType = "hub" | "branch";
-type HubStatus = "active" | "full" | "maintenance";
-
-interface Hub {
-  id: string;
-  name: string;
-  type: HubType;
-  address: string;
-  district: string;
-  city: string;
-  capacity: number;
-  currentLoad: number;
-  shippers: number;
-  pendingOrders: number;
-  status: HubStatus;
-  manager: string;
-}
-
-const HUBS: Hub[] = [
-  { id: "HUB-HCM-01", name: "Hub Trung Tâm HCM", type: "hub", address: "123 Nguyễn Huệ", district: "Quận 1", city: "TP.HCM", capacity: 500, currentLoad: 320, shippers: 45, pendingOrders: 87, status: "active", manager: "Nguyễn Ops" },
-  { id: "HUB-HCM-02", name: "Hub Gò Vấp", type: "hub", address: "456 Quang Trung", district: "Gò Vấp", city: "TP.HCM", capacity: 300, currentLoad: 295, shippers: 28, pendingOrders: 63, status: "full", manager: "Trần Quản" },
-  { id: "BR-HCM-01", name: "Chi nhánh Bình Thạnh", type: "branch", address: "789 Đinh Tiên Hoàng", district: "Bình Thạnh", city: "TP.HCM", capacity: 150, currentLoad: 80, shippers: 15, pendingOrders: 24, status: "active", manager: "Lê Phụ trách" },
-  { id: "BR-HCM-02", name: "Chi nhánh Tân Bình", type: "branch", address: "321 Cộng Hòa", district: "Tân Bình", city: "TP.HCM", capacity: 200, currentLoad: 45, shippers: 18, pendingOrders: 31, status: "maintenance", manager: "Phạm Quản" },
-  { id: "HUB-BD-01", name: "Hub Bình Dương", type: "hub", address: "654 Đại lộ Bình Dương", district: "Thủ Dầu Một", city: "Bình Dương", capacity: 400, currentLoad: 210, shippers: 32, pendingOrders: 55, status: "active", manager: "Võ Ops" },
-  { id: "BR-LA-01", name: "Chi nhánh Long An", type: "branch", address: "987 QL1A", district: "Tân An", city: "Long An", capacity: 120, currentLoad: 90, shippers: 10, pendingOrders: 18, status: "active", manager: "Đỗ Phụ trách" },
-];
-
-const STATUS_CONFIG: Record<HubStatus, { label: string; color: string; bg: string; border: string }> = {
-  active:      { label: "Hoạt động",   color: "text-emerald-400", bg: "bg-emerald-500/10",  border: "border-emerald-500/15" },
-  full:        { label: "Đầy tải",     color: "text-amber-400",   bg: "bg-amber-500/10",    border: "border-amber-500/15" },
-  maintenance: { label: "Bảo trì",    color: "text-slate-400",   bg: "bg-slate-500/10",    border: "border-slate-500/15" },
+const STATUS_CONFIG = {
+  active:   { label: "Hoạt động", color: "text-emerald-400", bg: "bg-emerald-500/10", border: "border-emerald-500/15" },
+  inactive: { label: "Tạm dừng",  color: "text-slate-400",   bg: "bg-slate-500/10",   border: "border-slate-500/15" },
 };
 
 export default function HubsPage() {
   const [typeFilter, setTypeFilter] = useState("all");
+  const [hubs, setHubs]             = useState<AdminHub[]>([]);
+  const [loading, setLoading]       = useState(true);
 
-  const filtered = typeFilter === "all" ? HUBS : HUBS.filter((h) => h.type === typeFilter);
-  const totalCapacity = HUBS.reduce((s, h) => s + h.capacity, 0);
-  const totalLoad = HUBS.reduce((s, h) => s + h.currentLoad, 0);
-  const totalShippers = HUBS.reduce((s, h) => s + h.shippers, 0);
-  const totalPending = HUBS.reduce((s, h) => s + h.pendingOrders, 0);
+  useEffect(() => {
+    getAllHubsAndBranches()
+      .then(setHubs)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = typeFilter === "all" ? hubs : hubs.filter((h) => h.type === typeFilter);
+  const totalHubs     = hubs.filter((h) => h.type === "hub").length;
+  const totalBranches = hubs.filter((h) => h.type === "branch").length;
+  const activeCount   = hubs.filter((h) => h.active).length;
+  const totalCapacity = hubs.reduce((s, h) => s + (h.maxCapacity ?? 0), 0);
 
   return (
     <AdminLayout>
@@ -55,7 +38,7 @@ export default function HubsPage() {
             <h1 className="text-xl font-bold text-white">Hub & Chi nhánh</h1>
             <p className="text-[13px] text-slate-500 mt-0.5">Quản lý mạng lưới kho vận và điểm giao dịch</p>
           </div>
-          <button className="inline-flex items-center gap-2 h-9 px-4 rounded-xl gradient-brand text-white text-[13px] font-semibold shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 transition-all cursor-pointer">
+          <button type="button" className="inline-flex items-center gap-2 h-9 px-4 rounded-xl gradient-brand text-white text-[13px] font-semibold shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 transition-all cursor-pointer">
             <Plus size={15} /> Thêm Hub
           </button>
         </div>
@@ -63,10 +46,10 @@ export default function HubsPage() {
         {/* System summary */}
         <div className="grid grid-cols-2 xl:grid-cols-4 gap-3 stagger">
           {[
-            { label: "Tổng công suất", value: `${totalCapacity}`, unit: "kiện", icon: Activity, color: "text-indigo-400", bg: "bg-indigo-500/[0.08]" },
-            { label: "Đang chứa", value: `${totalLoad}`, unit: `${Math.round(totalLoad/totalCapacity*100)}%`, icon: Package, color: "text-amber-400", bg: "bg-amber-500/[0.08]" },
-            { label: "Shipper tổng", value: `${totalShippers}`, unit: "người", icon: Users, color: "text-sky-400", bg: "bg-sky-500/[0.08]" },
-            { label: "Đơn chờ", value: `${totalPending}`, unit: "đơn", icon: Truck, color: "text-emerald-400", bg: "bg-emerald-500/[0.08]" },
+            { label: "Hub trung tâm",  value: String(totalHubs),     unit: "hub",      icon: Activity, color: "text-indigo-400", bg: "bg-indigo-500/[0.08]" },
+            { label: "Chi nhánh",      value: String(totalBranches),  unit: "chi nhánh",icon: MapPin,   color: "text-purple-400", bg: "bg-purple-500/[0.08]" },
+            { label: "Đang hoạt động", value: String(activeCount),    unit: "điểm",     icon: Users,    color: "text-sky-400",    bg: "bg-sky-500/[0.08]" },
+            { label: "Sức chứa tổng",  value: String(totalCapacity || "—"), unit: "kiện", icon: Package, color: "text-emerald-400", bg: "bg-emerald-500/[0.08]" },
           ].map((s) => {
             const Icon = s.icon;
             return (
@@ -77,7 +60,11 @@ export default function HubsPage() {
                   </div>
                   <span className="text-[11px] text-slate-500">{s.label}</span>
                 </div>
-                <p className="text-[24px] font-bold text-white">{s.value}</p>
+                {loading ? (
+                  <div className="h-7 w-10 bg-white/[0.06] rounded animate-pulse" />
+                ) : (
+                  <p className="text-[24px] font-bold text-white">{s.value}</p>
+                )}
                 <p className="text-[11px] text-slate-600">{s.unit}</p>
               </div>
             );
@@ -87,12 +74,13 @@ export default function HubsPage() {
         {/* Filter tabs */}
         <div className="flex gap-1.5">
           {[
-            { key: "all", label: "Tất cả" },
-            { key: "hub", label: "Hub chính" },
+            { key: "all",    label: "Tất cả" },
+            { key: "hub",    label: "Hub chính" },
             { key: "branch", label: "Chi nhánh" },
           ].map((f) => (
             <button
               key={f.key}
+              type="button"
               onClick={() => setTypeFilter(f.key)}
               className={`px-3.5 py-1.5 rounded-lg text-[12px] font-medium transition-all cursor-pointer border ${
                 typeFilter === f.key
@@ -106,69 +94,71 @@ export default function HubsPage() {
         </div>
 
         {/* Hub grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
-          {filtered.map((hub) => {
-            const sc = STATUS_CONFIG[hub.status];
-            const loadPct = Math.round((hub.currentLoad / hub.capacity) * 100);
-            const loadColor = loadPct >= 90 ? "#f87171" : loadPct >= 70 ? "#fbbf24" : "#34d399";
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader size={20} className="text-indigo-400 animate-spin" />
+            <span className="ml-2 text-[13px] text-slate-500">Đang tải dữ liệu hub...</span>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="glass rounded-2xl py-16 text-center">
+            <p className="text-[13px] text-slate-600">Chưa có hub hoặc chi nhánh nào</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+            {filtered.map((hub) => {
+              const sc = hub.active ? STATUS_CONFIG.active : STATUS_CONFIG.inactive;
+              const isHub = hub.type === "hub";
 
-            return (
-              <div key={hub.id} className="glass rounded-2xl p-5 hover:border-indigo-500/20 transition-all duration-200">
-                {/* Header */}
-                <div className="flex items-start justify-between mb-4">
-                  <div className="flex items-center gap-3">
-                    <div
-                      className={`h-10 w-10 rounded-xl flex items-center justify-center flex-shrink-0 ${hub.type === "hub" ? "bg-indigo-500/[0.12]" : "bg-purple-500/[0.12]"}`}
-                    >
-                      <MapPin size={16} className={hub.type === "hub" ? "text-indigo-400" : "text-purple-400"} />
+              return (
+                <div key={hub.id} className="glass rounded-2xl p-5 hover:border-indigo-500/20 transition-all duration-200">
+                  {/* Header */}
+                  <div className="flex items-start justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                      <div className={`h-10 w-10 rounded-xl flex items-center justify-center flex-shrink-0 ${isHub ? "bg-indigo-500/[0.12]" : "bg-purple-500/[0.12]"}`}>
+                        <MapPin size={16} className={isHub ? "text-indigo-400" : "text-purple-400"} />
+                      </div>
+                      <div>
+                        <p className="text-[13px] font-semibold text-white leading-tight">{hub.name}</p>
+                        <p className="text-[10px] text-slate-600">{hub.id}</p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-[13px] font-semibold text-white leading-tight">{hub.name}</p>
-                      <p className="text-[10px] text-slate-600">{hub.id}</p>
+                    <span className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-1 rounded-lg border ${sc.color} ${sc.bg} ${sc.border}`}>
+                      {sc.label}
+                    </span>
+                  </div>
+
+                  {/* Address */}
+                  <p className="text-[12px] text-slate-500 mb-3">
+                    {[hub.address, hub.province].filter(Boolean).join(", ") || "—"}
+                  </p>
+
+                  {/* Stats row */}
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="text-center rounded-xl bg-white/[0.03] border border-white/[0.04] py-2">
+                      <p className="text-[12px] font-bold text-white">{isHub ? "Hub" : "Branch"}</p>
+                      <p className="text-[9px] text-slate-600 uppercase tracking-wide mt-0.5">Loại</p>
+                    </div>
+                    <div className="text-center rounded-xl bg-white/[0.03] border border-white/[0.04] py-2">
+                      <p className="text-[12px] font-bold text-white">{hub.maxCapacity ?? "—"}</p>
+                      <p className="text-[9px] text-slate-600 uppercase tracking-wide mt-0.5">Sức chứa</p>
+                    </div>
+                    <div className="text-center rounded-xl bg-white/[0.03] border border-white/[0.04] py-2 flex flex-col items-center justify-center gap-0.5">
+                      <Phone size={10} className="text-slate-500" />
+                      <p className="text-[9px] text-slate-600 truncate w-full text-center px-1">{hub.contactPhone || "—"}</p>
                     </div>
                   </div>
-                  <span className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-1 rounded-lg border ${sc.color} ${sc.bg} ${sc.border}`}>
-                    {sc.label}
-                  </span>
-                </div>
 
-                {/* Address */}
-                <p className="text-[12px] text-slate-500 mb-4">
-                  {hub.address}, {hub.district}, {hub.city}
-                </p>
-
-                {/* Capacity bar */}
-                <div className="mb-4">
-                  <div className="flex items-center justify-between mb-1.5">
-                    <span className="text-[11px] text-slate-600">Công suất sử dụng</span>
-                    <span className="text-[11px] font-semibold" style={{ color: loadColor }}>{loadPct}%</span>
-                  </div>
-                  <div className="h-1.5 rounded-full bg-white/[0.06]">
-                    <div
-                      className="h-full rounded-full transition-all duration-500"
-                      style={{ width: `${loadPct}%`, background: loadColor, boxShadow: `0 0 8px ${loadColor}40` }}
-                    />
-                  </div>
-                  <p className="text-[10px] text-slate-700 mt-1">{hub.currentLoad} / {hub.capacity} kiện</p>
+                  {/* Hub parent info for branches */}
+                  {hub.hubName && (
+                    <p className="text-[11px] text-slate-600 mt-3">
+                      Thuộc hub: <span className="text-slate-400">{hub.hubName}</span>
+                    </p>
+                  )}
                 </div>
-
-                {/* Stats row */}
-                <div className="grid grid-cols-3 gap-2">
-                  {[
-                    { label: "Shipper", value: hub.shippers },
-                    { label: "Chờ giao", value: hub.pendingOrders },
-                    { label: "Quản lý", value: hub.manager.split(" ")[0] },
-                  ].map((stat) => (
-                    <div key={stat.label} className="text-center rounded-xl bg-white/[0.03] border border-white/[0.04] py-2">
-                      <p className="text-[13px] font-bold text-white">{stat.value}</p>
-                      <p className="text-[9px] text-slate-600 uppercase tracking-wide mt-0.5">{stat.label}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     </AdminLayout>
   );

--- a/apps/admin-web/src/app/orders/page.tsx
+++ b/apps/admin-web/src/app/orders/page.tsx
@@ -1,41 +1,41 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { AdminLayout } from "@/components/layout";
-import { Badge } from "@/components/ui";
 import {
-  Search, Filter, Eye, Package, Clock, CheckCircle,
-  Truck, XCircle, ChevronRight, ArrowUpRight,
+  Search, Package, Clock, CheckCircle,
+  Truck, XCircle, ChevronRight, Loader,
 } from "lucide-react";
+import { getAllAdminOrders, countOrdersByStatus } from "@picbox/utils";
+import type { AdminOrder } from "@picbox/utils";
 
-type OrderStatus = "pending" | "confirmed" | "picking" | "delivering" | "delivered" | "failed" | "cancelled";
+type AdminStatus =
+  | "pending" | "confirmed" | "picking"
+  | "delivering" | "delivered" | "failed" | "cancelled";
 
-interface Order {
-  id: string;
-  customer: string;
-  phone: string;
-  from: string;
-  to: string;
-  shipper: string | null;
-  amount: number;
-  cod: number;
-  weight: number;
-  status: OrderStatus;
-  created: string;
+const BE_TO_ADMIN: Record<string, AdminStatus> = {
+  pending:          "pending",
+  confirmed:        "confirmed",
+  picked_up:        "picking",
+  in_transit:       "delivering",
+  at_hub:           "delivering",
+  sorting:          "delivering",
+  out_for_delivery: "delivering",
+  delivered:        "delivered",
+  failed:           "failed",
+  returned:         "cancelled",
+  cancelled:        "cancelled",
+};
+
+function toAdminStatus(feStatus: string): AdminStatus {
+  return BE_TO_ADMIN[feStatus] ?? "pending";
 }
 
-const ORDERS: Order[] = [
-  { id: "PB-20260001", customer: "Nguyễn Văn A", phone: "0901234567", from: "Quận 1, HCM", to: "Quận 7, HCM", shipper: "Lê Shipper", amount: 35000, cod: 250000, weight: 1.5, status: "delivering", created: "14/05/2026 08:12" },
-  { id: "PB-20260002", customer: "Trần Thị B", phone: "0912345678", from: "Bình Thạnh, HCM", to: "Gò Vấp, HCM", shipper: null, amount: 28000, cod: 0, weight: 0.8, status: "pending", created: "14/05/2026 09:05" },
-  { id: "PB-20260003", customer: "Lê Văn C", phone: "0923456789", from: "Quận 3, HCM", to: "Thủ Đức, HCM", shipper: "Võ Shipper", amount: 42000, cod: 180000, weight: 2.1, status: "picking", created: "14/05/2026 09:30" },
-  { id: "PB-20260004", customer: "Phạm Thị D", phone: "0934567890", from: "Quận 10, HCM", to: "Bình Dương", shipper: "Đặng Driver", amount: 68000, cod: 0, weight: 4.5, status: "delivered", created: "13/05/2026 15:00" },
-  { id: "PB-20260005", customer: "Hoàng Văn E", phone: "0945678901", from: "Tân Bình, HCM", to: "Long An", shipper: null, amount: 55000, cod: 320000, weight: 3.0, status: "confirmed", created: "14/05/2026 10:00" },
-  { id: "PB-20260006", customer: "Vũ Thị F", phone: "0956789012", from: "Quận 12, HCM", to: "Quận 9, HCM", shipper: "Ngô Shipper", amount: 25000, cod: 90000, weight: 0.5, status: "failed", created: "13/05/2026 14:20" },
-  { id: "PB-20260007", customer: "Đỗ Văn G", phone: "0967890123", from: "Nhà Bè, HCM", to: "Quận 4, HCM", shipper: null, amount: 33000, cod: 0, weight: 1.2, status: "cancelled", created: "13/05/2026 11:00" },
-  { id: "PB-20260008", customer: "Bùi Thị H", phone: "0978901234", from: "Cần Giờ, HCM", to: "Quận 1, HCM", shipper: "Trần Shipper", amount: 80000, cod: 500000, weight: 6.0, status: "delivering", created: "14/05/2026 07:45" },
-];
-
-const STATUS_CONFIG: Record<OrderStatus, { label: string; variant: "default" | "success" | "warning" | "danger" | "info"; icon: React.ElementType }> = {
+const STATUS_CONFIG: Record<AdminStatus, {
+  label: string;
+  variant: "default" | "success" | "warning" | "danger" | "info";
+  icon: React.ElementType;
+}> = {
   pending:    { label: "Chờ xử lý",   variant: "default",  icon: Clock },
   confirmed:  { label: "Đã xác nhận", variant: "info",     icon: CheckCircle },
   picking:    { label: "Đang lấy",    variant: "warning",  icon: Package },
@@ -46,31 +46,72 @@ const STATUS_CONFIG: Record<OrderStatus, { label: string; variant: "default" | "
 };
 
 const STATUS_TABS = [
-  { key: "all", label: "Tất cả" },
-  { key: "pending", label: "Chờ xử lý" },
-  { key: "delivering", label: "Đang giao" },
+  { key: "all",       label: "Tất cả" },
+  { key: "pending",   label: "Chờ xử lý" },
+  { key: "delivering",label: "Đang giao" },
   { key: "delivered", label: "Hoàn thành" },
-  { key: "failed", label: "Thất bại" },
+  { key: "failed",    label: "Thất bại" },
 ];
 
-const SUMMARY = [
-  { label: "Tổng đơn hôm nay", value: "248", icon: Package, color: "text-indigo-400", bg: "bg-indigo-500/[0.08]" },
-  { label: "Đang giao", value: "87", icon: Truck, color: "text-sky-400", bg: "bg-sky-500/[0.08]" },
-  { label: "Hoàn thành", value: "143", icon: CheckCircle, color: "text-emerald-400", bg: "bg-emerald-500/[0.08]" },
-  { label: "Thất bại", value: "18", icon: XCircle, color: "text-rose-400", bg: "bg-rose-500/[0.08]" },
-];
+function formatDate(iso: string) {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("vi-VN", {
+      day: "2-digit", month: "2-digit", year: "numeric",
+      hour: "2-digit", minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
 
 export default function OrdersPage() {
   const [tab, setTab] = useState("all");
   const [search, setSearch] = useState("");
-  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+  const [selectedOrder, setSelectedOrder] = useState<AdminOrder | null>(null);
+  const [orders, setOrders] = useState<AdminOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [stats, setStats] = useState({ total: 0, delivering: 0, delivered: 0, failed: 0 });
 
-  const filtered = ORDERS.filter((o) => {
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([
+      getAllAdminOrders(),
+      countOrdersByStatus("PENDING"),
+      countOrdersByStatus("OUT_FOR_DELIVERY"),
+      countOrdersByStatus("DELIVERED"),
+      countOrdersByStatus("DELIVERY_FAILED"),
+    ]).then(([data, pending, delivering, delivered, failed]) => {
+      setOrders(data);
+      setStats({
+        total: pending + delivering + delivered + failed,
+        delivering,
+        delivered,
+        failed,
+      });
+    }).catch(console.error).finally(() => setLoading(false));
+  }, []);
+
+  const filtered = orders.filter((o) => {
     const q = search.toLowerCase();
-    const matchSearch = o.id.toLowerCase().includes(q) || o.customer.toLowerCase().includes(q) || o.to.toLowerCase().includes(q);
-    const matchTab = tab === "all" || o.status === tab;
+    const adminStatus = toAdminStatus(o.status);
+    const matchSearch =
+      o.trackingCode.toLowerCase().includes(q) ||
+      o.senderName.toLowerCase().includes(q) ||
+      o.receiverName.toLowerCase().includes(q) ||
+      o.receiverAddress.toLowerCase().includes(q);
+    const matchTab =
+      tab === "all" ||
+      adminStatus === tab;
     return matchSearch && matchTab;
   });
+
+  const SUMMARY = [
+    { label: "Tổng đơn hôm nay", value: String(stats.total), icon: Package, color: "text-indigo-400", bg: "bg-indigo-500/[0.08]" },
+    { label: "Đang giao",        value: String(stats.delivering), icon: Truck,   color: "text-sky-400",    bg: "bg-sky-500/[0.08]" },
+    { label: "Hoàn thành",       value: String(stats.delivered),  icon: CheckCircle, color: "text-emerald-400", bg: "bg-emerald-500/[0.08]" },
+    { label: "Thất bại",         value: String(stats.failed),     icon: XCircle, color: "text-rose-400",   bg: "bg-rose-500/[0.08]" },
+  ];
 
   return (
     <AdminLayout>
@@ -91,7 +132,11 @@ export default function OrdersPage() {
                   <Icon size={18} className={s.color} />
                 </div>
                 <div>
-                  <p className="text-[22px] font-bold text-white leading-none">{s.value}</p>
+                  {loading ? (
+                    <div className="h-6 w-12 bg-white/[0.06] rounded animate-pulse" />
+                  ) : (
+                    <p className="text-[22px] font-bold text-white leading-none">{s.value}</p>
+                  )}
                   <p className="text-[11px] text-slate-500 mt-0.5">{s.label}</p>
                 </div>
               </div>
@@ -106,7 +151,7 @@ export default function OrdersPage() {
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Tìm mã đơn, khách hàng, địa chỉ..."
+              placeholder="Tìm mã vận đơn, người gửi, người nhận..."
               className="w-full h-9 rounded-xl bg-white/[0.04] border border-white/[0.08] pl-9 pr-4 text-[13px] text-slate-300 placeholder-slate-600 outline-none transition-all focus:border-indigo-500/40"
             />
           </div>
@@ -129,156 +174,151 @@ export default function OrdersPage() {
 
         {/* Table + Detail panel */}
         <div className="flex gap-4">
-          {/* Table */}
           <div className={`glass rounded-2xl overflow-hidden flex-1 min-w-0 ${selectedOrder ? "hidden xl:block" : ""}`}>
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
-                    {["Mã đơn", "Khách hàng", "Tuyến đường", "Shipper", "Thu hộ", "Trạng thái", ""].map((h) => (
-                      <th key={h} className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((order) => {
-                    const s = STATUS_CONFIG[order.status];
-                    const Icon = s.icon;
-                    return (
-                      <tr
-                        key={order.id}
-                        onClick={() => setSelectedOrder(order)}
-                        className="hover:bg-white/[0.02] transition-colors cursor-pointer"
-                        style={{ borderBottom: "1px solid rgba(255,255,255,0.03)" }}
-                      >
-                        <td className="px-4 py-3">
-                          <div className="flex items-center gap-2">
-                            <div className="h-8 w-8 rounded-lg bg-indigo-500/[0.08] flex items-center justify-center flex-shrink-0">
-                              <Package size={13} className="text-indigo-400" />
-                            </div>
-                            <div>
-                              <p className="text-[12px] font-semibold text-white">{order.id}</p>
-                              <p className="text-[10px] text-slate-600">{order.created}</p>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3">
-                          <p className="text-[13px] text-white">{order.customer}</p>
-                          <p className="text-[11px] text-slate-500">{order.phone}</p>
-                        </td>
-                        <td className="px-4 py-3">
-                          <p className="text-[12px] text-slate-400 flex items-center gap-1">
-                            <span className="truncate max-w-[80px]">{order.from}</span>
-                            <ChevronRight size={10} className="flex-shrink-0 text-slate-600" />
-                            <span className="truncate max-w-[80px]">{order.to}</span>
-                          </p>
-                        </td>
-                        <td className="px-4 py-3 text-[12px] text-slate-400">{order.shipper ?? <span className="text-slate-700 italic">Chưa gán</span>}</td>
-                        <td className="px-4 py-3 text-[12px] text-slate-300">
-                          {order.cod > 0 ? `₫${order.cod.toLocaleString()}` : <span className="text-slate-700">—</span>}
-                        </td>
-                        <td className="px-4 py-3">
-                          <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold border ${
-                            s.variant === "success" ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/15" :
-                            s.variant === "danger"  ? "bg-rose-500/10 text-rose-400 border-rose-500/15" :
-                            s.variant === "warning" ? "bg-amber-500/10 text-amber-400 border-amber-500/15" :
-                            s.variant === "info"    ? "bg-sky-500/10 text-sky-400 border-sky-500/15" :
-                                                      "bg-slate-500/10 text-slate-400 border-slate-500/15"
-                          }`}>
-                            <Icon size={10} />
-                            {s.label}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3">
-                          <button className="p-1.5 rounded-lg text-slate-600 hover:text-white hover:bg-white/[0.06] transition-all cursor-pointer">
-                            <Eye size={13} />
-                          </button>
+            {loading ? (
+              <div className="flex items-center justify-center py-16">
+                <Loader size={20} className="text-indigo-400 animate-spin" />
+                <span className="ml-2 text-[13px] text-slate-500">Đang tải đơn hàng...</span>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+                      {["Mã vận đơn", "Người gửi", "Tuyến đường", "Người nhận", "Thu hộ", "Trạng thái", ""].map((h) => (
+                        <th key={h} className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-10 text-center text-[13px] text-slate-600">
+                          Không có đơn hàng nào
                         </td>
                       </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-            <div className="flex items-center justify-between px-4 py-3" style={{ borderTop: "1px solid rgba(255,255,255,0.04)" }}>
-              <p className="text-[12px] text-slate-600">Hiển thị {filtered.length} / {ORDERS.length} đơn hàng</p>
-              <div className="flex items-center gap-1">
-                {[1,2,3].map((p) => (
-                  <button key={p} className={`h-7 w-7 rounded-lg text-[12px] font-medium transition-all cursor-pointer ${p===1?"bg-indigo-500/15 text-indigo-400":"text-slate-500 hover:bg-white/[0.04]"}`}>{p}</button>
-                ))}
+                    ) : filtered.map((order) => {
+                      const adminStatus = toAdminStatus(order.status);
+                      const s = STATUS_CONFIG[adminStatus];
+                      const Icon = s.icon;
+                      return (
+                        <tr
+                          key={order.id}
+                          onClick={() => setSelectedOrder(order)}
+                          className="hover:bg-white/[0.02] transition-colors cursor-pointer"
+                          style={{ borderBottom: "1px solid rgba(255,255,255,0.03)" }}
+                        >
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <div className="h-8 w-8 rounded-lg bg-indigo-500/[0.08] flex items-center justify-center flex-shrink-0">
+                                <Package size={13} className="text-indigo-400" />
+                              </div>
+                              <div>
+                                <p className="text-[12px] font-semibold text-white">{order.trackingCode}</p>
+                                <p className="text-[10px] text-slate-600">{formatDate(order.createdAt)}</p>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <p className="text-[13px] text-white">{order.senderName}</p>
+                            <p className="text-[11px] text-slate-500">{order.senderPhone}</p>
+                          </td>
+                          <td className="px-4 py-3">
+                            <p className="text-[12px] text-slate-400 flex items-center gap-1">
+                              <span className="truncate max-w-[80px]">{order.originBranchName}</span>
+                              <ChevronRight size={10} className="flex-shrink-0 text-slate-600" />
+                              <span className="truncate max-w-[80px]">{order.destBranchName}</span>
+                            </p>
+                          </td>
+                          <td className="px-4 py-3">
+                            <p className="text-[13px] text-white">{order.receiverName}</p>
+                            <p className="text-[11px] text-slate-500">{order.receiverPhone}</p>
+                          </td>
+                          <td className="px-4 py-3 text-[12px] text-slate-300">
+                            {order.codAmount > 0 ? `₫${order.codAmount.toLocaleString()}` : <span className="text-slate-700">—</span>}
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold border ${
+                              s.variant === "success" ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/15" :
+                              s.variant === "danger"  ? "bg-rose-500/10 text-rose-400 border-rose-500/15" :
+                              s.variant === "warning" ? "bg-amber-500/10 text-amber-400 border-amber-500/15" :
+                              s.variant === "info"    ? "bg-sky-500/10 text-sky-400 border-sky-500/15" :
+                                                        "bg-slate-500/10 text-slate-400 border-slate-500/15"
+                            }`}>
+                              <Icon size={10} />
+                              {s.label}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <button type="button" title="Xem chi tiết" className="p-1.5 rounded-lg text-slate-600 hover:text-white hover:bg-white/[0.06] transition-all cursor-pointer">
+                              <ChevronRight size={13} />
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
+            )}
+            <div className="flex items-center justify-between px-4 py-3" style={{ borderTop: "1px solid rgba(255,255,255,0.04)" }}>
+              <p className="text-[12px] text-slate-600">Hiển thị {filtered.length} / {orders.length} đơn hàng</p>
             </div>
           </div>
 
           {/* Order detail panel */}
-          {selectedOrder && (
-            <div className="w-full xl:w-80 flex-shrink-0 glass rounded-2xl p-5 animate-slideDown">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-[14px] font-semibold text-white">Chi tiết đơn hàng</h3>
-                <button onClick={() => setSelectedOrder(null)} className="p-1 rounded-lg text-slate-500 hover:text-white hover:bg-white/[0.06] cursor-pointer transition-all">
-                  <XCircle size={15} />
-                </button>
-              </div>
-
-              {/* Status */}
-              {(() => {
-                const s = STATUS_CONFIG[selectedOrder.status];
-                const Icon = s.icon;
-                return (
-                  <div className={`flex items-center gap-2 rounded-xl px-3 py-2 mb-4 ${
-                    s.variant === "success" ? "bg-emerald-500/10 border border-emerald-500/15" :
-                    s.variant === "danger"  ? "bg-rose-500/10 border border-rose-500/15" :
-                    s.variant === "warning" ? "bg-amber-500/10 border border-amber-500/15" :
-                    s.variant === "info"    ? "bg-sky-500/10 border border-sky-500/15" :
-                                              "bg-slate-500/10 border border-slate-500/15"
-                  }`}>
-                    <Icon size={14} className={
-                      s.variant === "success" ? "text-emerald-400" :
-                      s.variant === "danger"  ? "text-rose-400" :
-                      s.variant === "warning" ? "text-amber-400" :
-                      s.variant === "info"    ? "text-sky-400" : "text-slate-400"
-                    } />
-                    <span className="text-[13px] font-semibold text-white">{s.label}</span>
-                  </div>
-                );
-              })()}
-
-              <div className="space-y-3">
-                {[
-                  { label: "Mã đơn", value: selectedOrder.id },
-                  { label: "Khách hàng", value: selectedOrder.customer },
-                  { label: "Điện thoại", value: selectedOrder.phone },
-                  { label: "Từ", value: selectedOrder.from },
-                  { label: "Đến", value: selectedOrder.to },
-                  { label: "Shipper", value: selectedOrder.shipper ?? "Chưa gán" },
-                  { label: "Cước phí", value: `₫${selectedOrder.amount.toLocaleString()}` },
-                  { label: "Thu hộ (COD)", value: selectedOrder.cod > 0 ? `₫${selectedOrder.cod.toLocaleString()}` : "Không có" },
-                  { label: "Trọng lượng", value: `${selectedOrder.weight} kg` },
-                  { label: "Ngày tạo", value: selectedOrder.created },
-                ].map((row) => (
-                  <div key={row.label} className="flex items-start justify-between gap-2">
-                    <span className="text-[11px] text-slate-600 flex-shrink-0">{row.label}</span>
-                    <span className="text-[12px] text-slate-300 text-right">{row.value}</span>
-                  </div>
-                ))}
-              </div>
-
-              {/* Status update */}
-              {(selectedOrder.status === "pending" || selectedOrder.status === "confirmed") && (
-                <div className="mt-5 pt-4" style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-                  <p className="text-[11px] text-slate-600 mb-2">Cập nhật trạng thái</p>
-                  <div className="space-y-2">
-                    <button className="w-full h-9 rounded-xl bg-indigo-500/15 text-indigo-400 border border-indigo-500/20 text-[12px] font-medium hover:bg-indigo-500/25 transition-all cursor-pointer flex items-center justify-center gap-2">
-                      <Truck size={13} /> Gán shipper
-                    </button>
-                    <button className="w-full h-9 rounded-xl bg-rose-500/10 text-rose-400 border border-rose-500/15 text-[12px] font-medium hover:bg-rose-500/15 transition-all cursor-pointer flex items-center justify-center gap-2">
-                      <XCircle size={13} /> Huỷ đơn
-                    </button>
-                  </div>
+          {selectedOrder && (() => {
+            const adminStatus = toAdminStatus(selectedOrder.status);
+            const s = STATUS_CONFIG[adminStatus];
+            const Icon = s.icon;
+            return (
+              <div className="w-full xl:w-80 flex-shrink-0 glass rounded-2xl p-5 animate-slideDown">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-[14px] font-semibold text-white">Chi tiết đơn hàng</h3>
+                  <button type="button" title="Đóng" onClick={() => setSelectedOrder(null)} className="p-1 rounded-lg text-slate-500 hover:text-white hover:bg-white/[0.06] cursor-pointer transition-all">
+                    <XCircle size={15} />
+                  </button>
                 </div>
-              )}
-            </div>
-          )}
+
+                <div className={`flex items-center gap-2 rounded-xl px-3 py-2 mb-4 ${
+                  s.variant === "success" ? "bg-emerald-500/10 border border-emerald-500/15" :
+                  s.variant === "danger"  ? "bg-rose-500/10 border border-rose-500/15" :
+                  s.variant === "warning" ? "bg-amber-500/10 border border-amber-500/15" :
+                  s.variant === "info"    ? "bg-sky-500/10 border border-sky-500/15" :
+                                            "bg-slate-500/10 border border-slate-500/15"
+                }`}>
+                  <Icon size={14} className={
+                    s.variant === "success" ? "text-emerald-400" :
+                    s.variant === "danger"  ? "text-rose-400" :
+                    s.variant === "warning" ? "text-amber-400" :
+                    s.variant === "info"    ? "text-sky-400" : "text-slate-400"
+                  } />
+                  <span className="text-[13px] font-semibold text-white">{s.label}</span>
+                </div>
+
+                <div className="space-y-3">
+                  {[
+                    { label: "Mã vận đơn",   value: selectedOrder.trackingCode },
+                    { label: "Người gửi",     value: selectedOrder.senderName },
+                    { label: "SĐT gửi",       value: selectedOrder.senderPhone },
+                    { label: "Người nhận",    value: selectedOrder.receiverName },
+                    { label: "SĐT nhận",      value: selectedOrder.receiverPhone },
+                    { label: "Địa chỉ nhận",  value: selectedOrder.receiverAddress },
+                    { label: "Tuyến",         value: `${selectedOrder.originBranchName} → ${selectedOrder.destBranchName}` },
+                    { label: "Cước phí",      value: `₫${selectedOrder.fee.toLocaleString()}` },
+                    { label: "Thu hộ (COD)",  value: selectedOrder.codAmount > 0 ? `₫${selectedOrder.codAmount.toLocaleString()}` : "Không có" },
+                    { label: "Trọng lượng",   value: `${selectedOrder.weight} kg` },
+                    { label: "Ngày tạo",      value: formatDate(selectedOrder.createdAt) },
+                  ].map((row) => (
+                    <div key={row.label} className="flex items-start justify-between gap-2">
+                      <span className="text-[11px] text-slate-600 flex-shrink-0">{row.label}</span>
+                      <span className="text-[12px] text-slate-300 text-right">{row.value}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
         </div>
       </div>
     </AdminLayout>

--- a/apps/admin-web/src/app/page.tsx
+++ b/apps/admin-web/src/app/page.tsx
@@ -1,11 +1,59 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { AdminLayout } from "@/components/layout";
-import { StatCard } from "@/components/ui";
-import { Badge } from "@/components/ui";
-import { Package, Users, Truck, TrendingUp, ArrowUpRight } from "lucide-react";
+import { StatCard, Badge } from "@/components/ui";
+import { Package, Users, Truck, TrendingUp, ArrowUpRight, Loader } from "lucide-react";
+import { getDashboardStats, getAllAdminOrders } from "@picbox/utils";
+import type { DashboardStats, AdminOrder } from "@picbox/utils";
+
+const STATUS_LABEL: Record<string, { label: string; variant: "default" | "success" | "warning" | "info" | "danger" }> = {
+  pending:          { label: "Chờ xử lý",   variant: "default" },
+  confirmed:        { label: "Đã xác nhận", variant: "info" },
+  picked_up:        { label: "Đang lấy",    variant: "warning" },
+  in_transit:       { label: "Vận chuyển",  variant: "info" },
+  at_hub:           { label: "Tại hub",     variant: "info" },
+  sorting:          { label: "Phân loại",   variant: "warning" },
+  out_for_delivery: { label: "Đang giao",   variant: "info" },
+  delivered:        { label: "Hoàn thành",  variant: "success" },
+  failed:           { label: "Thất bại",    variant: "danger" },
+  returned:         { label: "Đã hoàn",     variant: "danger" },
+  cancelled:        { label: "Đã huỷ",      variant: "danger" },
+};
+
+function formatCurrency(n: number) {
+  if (n >= 1_000_000_000) return `₫${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000)     return `₫${(n / 1_000_000).toFixed(0)}M`;
+  return `₫${n.toLocaleString()}`;
+}
+
+function timeAgo(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1)  return "vừa xong";
+  if (m < 60) return `${m} phút trước`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} giờ trước`;
+  return `${Math.floor(h / 24)} ngày trước`;
+}
 
 export default function DashboardPage() {
+  const [stats, setStats]           = useState<DashboardStats | null>(null);
+  const [recentOrders, setRecentOrders] = useState<AdminOrder[]>([]);
+  const [loading, setLoading]       = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      getDashboardStats(),
+      getAllAdminOrders(),
+    ]).then(([s, orders]) => {
+      setStats(s);
+      setRecentOrders(orders.slice(0, 5));
+    }).catch(console.error).finally(() => setLoading(false));
+  }, []);
+
+  const totalRevenue = recentOrders.reduce((s, o) => s + o.fee, 0);
+
   return (
     <AdminLayout>
       <div className="space-y-6">
@@ -13,29 +61,29 @@ export default function DashboardPage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 stagger">
           <StatCard
             title="Tổng đơn hàng"
-            value="12,847"
-            change="↑ 12.5% so với tuần trước"
+            value={loading ? "..." : String(stats?.totalOrders ?? 0)}
+            change={loading ? "" : `${stats?.deliveredOrders ?? 0} đã hoàn thành`}
             changeType="positive"
             icon={<Package size={22} />}
           />
           <StatCard
             title="Người dùng"
-            value="3,241"
-            change="↑ 8.2% so với tuần trước"
+            value={loading ? "..." : String(stats?.totalUsers ?? 0)}
+            change="Tổng khách hàng"
             changeType="positive"
             icon={<Users size={22} />}
           />
           <StatCard
             title="Shipper hoạt động"
-            value="186"
-            change="↓ 2.1% so với hôm qua"
-            changeType="negative"
+            value={loading ? "..." : String(stats?.totalShippers ?? 0)}
+            change="Đang trong hệ thống"
+            changeType="positive"
             icon={<Truck size={22} />}
           />
           <StatCard
-            title="Doanh thu tháng"
-            value="₫2.4B"
-            change="↑ 18.3% so với tháng trước"
+            title="Doanh thu ước tính"
+            value={loading ? "..." : formatCurrency(totalRevenue)}
+            change="Từ đơn đã ghi nhận"
             changeType="positive"
             icon={<TrendingUp size={22} />}
           />
@@ -47,39 +95,50 @@ export default function DashboardPage() {
           <div className="lg:col-span-2 rounded-2xl glass p-5 animate-fadeIn">
             <div className="flex items-center justify-between mb-6">
               <h3 className="text-[19px] font-semibold text-white">Đơn hàng gần đây</h3>
-              <button className="text-[16px] text-indigo-400 hover:text-indigo-300 flex items-center gap-2 transition-colors cursor-pointer">
+              <a href="/orders" className="text-[13px] text-indigo-400 hover:text-indigo-300 flex items-center gap-1 transition-colors">
                 Xem tất cả <ArrowUpRight size={12} />
-              </button>
+              </a>
             </div>
-            <div className="space-y-3.5">
-              {[
-                { id: "PB-20241201", status: "Đang giao", customer: "Nguyễn Văn A", amount: "₫125,000", time: "5 phút trước", variant: "info" as const },
-                { id: "PB-20241200", status: "Đã nhận", customer: "Trần Thị B", amount: "₫89,000", time: "12 phút trước", variant: "warning" as const },
-                { id: "PB-20241199", status: "Hoàn thành", customer: "Lê Văn C", amount: "₫210,000", time: "25 phút trước", variant: "success" as const },
-                { id: "PB-20241198", status: "Đang xử lý", customer: "Phạm Thị D", amount: "₫45,000", time: "30 phút trước", variant: "default" as const },
-                { id: "PB-20241197", status: "Hoàn thành", customer: "Hoàng Văn E", amount: "₫320,000", time: "1 giờ trước", variant: "success" as const },
-              ].map((order) => (
-                <div
-                  key={order.id}
-                  className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-0 rounded-xl bg-white/[0.02] hover:bg-white/[0.04] border border-white/[0.04] p-3.5 transition-all duration-200 cursor-pointer group"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="h-12 w-12 rounded-xl bg-indigo-500/[0.08] flex items-center justify-center group-hover:bg-indigo-500/[0.12] transition-colors">
-                      <Package size={20} className="text-indigo-400" />
+
+            {loading ? (
+              <div className="flex items-center justify-center py-10">
+                <Loader size={18} className="text-indigo-400 animate-spin" />
+                <span className="ml-2 text-[13px] text-slate-500">Đang tải...</span>
+              </div>
+            ) : recentOrders.length === 0 ? (
+              <p className="text-center text-[13px] text-slate-600 py-10">Chưa có đơn hàng nào</p>
+            ) : (
+              <div className="space-y-3.5">
+                {recentOrders.map((order) => {
+                  const sv = STATUS_LABEL[order.status] ?? STATUS_LABEL.pending;
+                  return (
+                    <div
+                      key={order.id}
+                      className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-0 rounded-xl bg-white/[0.02] hover:bg-white/[0.04] border border-white/[0.04] p-3.5 transition-all duration-200 cursor-pointer group"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="h-10 w-10 rounded-xl bg-indigo-500/[0.08] flex items-center justify-center group-hover:bg-indigo-500/[0.12] transition-colors flex-shrink-0">
+                          <Package size={18} className="text-indigo-400" />
+                        </div>
+                        <div>
+                          <p className="text-[14px] font-semibold text-white">{order.trackingCode}</p>
+                          <p className="text-[12px] text-slate-500">{order.senderName} → {order.receiverName}</p>
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between sm:justify-end gap-3 w-full sm:w-auto">
+                        <span className="text-[13px] font-medium text-slate-300 hidden sm:block">
+                          {formatCurrency(order.fee)}
+                        </span>
+                        <Badge variant={sv.variant}>{sv.label}</Badge>
+                        <span className="text-[12px] text-slate-600 hidden md:block w-24 text-right">
+                          {timeAgo(order.createdAt)}
+                        </span>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-[17px] font-semibold text-white">{order.id}</p>
-                      <p className="text-[15px] text-slate-500">{order.customer}</p>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-4 w-full sm:w-auto">
-                    <span className="text-[17px] font-medium text-slate-300 hidden sm:block">{order.amount}</span>
-                    <Badge variant={order.variant}>{order.status}</Badge>
-                    <span className="text-[15px] text-slate-600 hidden md:block w-24 text-right">{order.time}</span>
-                  </div>
-                </div>
-              ))}
-            </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
 
           {/* System status */}
@@ -87,30 +146,41 @@ export default function DashboardPage() {
             <h3 className="text-[19px] font-semibold text-white mb-6">Trạng thái hệ thống</h3>
             <div className="space-y-4">
               {[
-                { name: "Gateway API", status: "online", uptime: "99.9%" },
-                { name: "Identity Service", status: "online", uptime: "99.8%" },
-                { name: "Order Service", status: "online", uptime: "99.7%" },
-                { name: "Payment Service", status: "online", uptime: "99.9%" },
-                { name: "Tracking Service", status: "online", uptime: "99.5%" },
-                { name: "Notification", status: "degraded", uptime: "98.2%" },
-                { name: "Kafka Cluster", status: "online", uptime: "99.9%" },
-                { name: "Redis Cache", status: "online", uptime: "100%" },
+                { name: "Gateway API",       status: "online" },
+                { name: "Identity Service",  status: "online" },
+                { name: "Order Service",     status: "online" },
+                { name: "Payment Service",   status: "online" },
+                { name: "Tracking Service",  status: "online" },
+                { name: "Notification",      status: "online" },
+                { name: "Kafka Cluster",     status: "online" },
+                { name: "Redis Cache",       status: "online" },
               ].map((svc) => (
                 <div key={svc.name} className="flex items-center justify-between py-1">
                   <div className="flex items-center gap-2">
-                    <span
-                      className={`h-2.5 w-2.5 rounded-full ${
-                        svc.status === "online"
-                          ? "bg-emerald-400 shadow-sm shadow-emerald-400/40"
-                          : "bg-amber-400 shadow-sm shadow-amber-400/40 animate-pulse"
-                      }`}
-                    />
-                    <span className="text-[17px] text-slate-300">{svc.name}</span>
+                    <span className="h-2.5 w-2.5 rounded-full bg-emerald-400 shadow-sm shadow-emerald-400/40" />
+                    <span className="text-[14px] text-slate-300">{svc.name}</span>
                   </div>
-                  <span className="text-[15px] text-slate-600 font-mono">{svc.uptime}</span>
+                  <span className="text-[12px] text-emerald-500 font-mono">Online</span>
                 </div>
               ))}
             </div>
+
+            {/* Quick stats */}
+            {!loading && stats && (
+              <div className="mt-6 pt-4 border-t border-white/[0.06] space-y-2">
+                <p className="text-[11px] text-slate-600 uppercase tracking-wide mb-3">Thống kê nhanh</p>
+                {[
+                  { label: "Đang giao",  value: stats.deliveringOrders, color: "text-sky-400" },
+                  { label: "Hoàn thành", value: stats.deliveredOrders,  color: "text-emerald-400" },
+                  { label: "Thất bại",   value: stats.failedOrders,     color: "text-rose-400" },
+                ].map((row) => (
+                  <div key={row.label} className="flex items-center justify-between">
+                    <span className="text-[12px] text-slate-500">{row.label}</span>
+                    <span className={`text-[13px] font-bold ${row.color}`}>{row.value}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/apps/admin-web/src/app/users/page.tsx
+++ b/apps/admin-web/src/app/users/page.tsx
@@ -1,60 +1,90 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { AdminLayout } from "@/components/layout";
 import { Badge } from "@/components/ui";
-import { Plus, Search, Edit2, Trash2, X, Filter } from "lucide-react";
+import { Plus, Search, Trash2, X, Loader } from "lucide-react";
+import { getAllUsers, deleteUser, apiRegister } from "@picbox/utils";
+import type { AdminUser } from "@picbox/utils";
 
-type UserRole = "admin" | "ops" | "shipper" | "driver" | "sender";
-type UserStatus = "active" | "inactive" | "suspended" | "pending";
+const ROLE_CONFIG: Record<string, { label: string; variant: "danger" | "warning" | "info" | "default" }> = {
+  admin:   { label: "Admin",       variant: "danger" },
+  ops:     { label: "Ops Manager", variant: "warning" },
+  shipper: { label: "Shipper",     variant: "info" },
+  driver:  { label: "Driver",      variant: "info" },
+  sender:  { label: "Sender",      variant: "default" },
+};
 
-interface UserData {
-  id: string;
-  name: string;
-  email: string;
-  phone: string;
-  role: UserRole;
-  status: UserStatus;
-  created: string;
-}
-
-const users: UserData[] = [
-  { id: "1", name: "Nguyễn Admin", email: "admin@picbox.vn", phone: "0901234567", role: "admin", status: "active", created: "15/01/2026" },
-  { id: "2", name: "Trần Ops Manager", email: "ops01@picbox.vn", phone: "0912345678", role: "ops", status: "active", created: "01/02/2026" },
-  { id: "3", name: "Lê Shipper Một", email: "shipper01@picbox.vn", phone: "0923456789", role: "shipper", status: "active", created: "10/02/2026" },
-  { id: "4", name: "Phạm Driver", email: "driver01@picbox.vn", phone: "0934567890", role: "driver", status: "inactive", created: "01/03/2026" },
-  { id: "5", name: "Hoàng Sender", email: "sender01@picbox.vn", phone: "0945678901", role: "sender", status: "active", created: "15/03/2026" },
-  { id: "6", name: "Võ Shipper Hai", email: "shipper02@picbox.vn", phone: "0956789012", role: "shipper", status: "suspended", created: "20/03/2026" },
-  { id: "7", name: "Đặng Driver Hai", email: "driver02@picbox.vn", phone: "0967890123", role: "driver", status: "active", created: "01/04/2026" },
-  { id: "8", name: "Bùi Sender Hai", email: "sender02@picbox.vn", phone: "0978901234", role: "sender", status: "pending", created: "10/04/2026" },
+const ROLE_TABS = [
+  { key: "all",     label: "Tất cả" },
+  { key: "admin",   label: "Admin" },
+  { key: "ops",     label: "Ops" },
+  { key: "shipper", label: "Shipper" },
+  { key: "driver",  label: "Driver" },
+  { key: "sender",  label: "Sender" },
 ];
 
-const roleConfig: Record<UserRole, { label: string; variant: "danger" | "warning" | "info" | "default" }> = {
-  admin: { label: "Admin", variant: "danger" },
-  ops: { label: "Ops Manager", variant: "warning" },
-  shipper: { label: "Shipper", variant: "info" },
-  driver: { label: "Driver", variant: "info" },
-  sender: { label: "Sender", variant: "default" },
-};
-
-const statusConfig: Record<UserStatus, { label: string; variant: "success" | "default" | "danger" | "warning" }> = {
-  active: { label: "Hoạt động", variant: "success" },
-  inactive: { label: "Ngưng", variant: "default" },
-  suspended: { label: "Bị khóa", variant: "danger" },
-  pending: { label: "Chờ duyệt", variant: "warning" },
-};
-
 export default function UsersPage() {
-  const [search, setSearch] = useState("");
-  const [roleFilter, setRoleFilter] = useState<string>("all");
+  const [search, setSearch]       = useState("");
+  const [roleFilter, setRoleFilter] = useState("all");
   const [modalOpen, setModalOpen] = useState(false);
+  const [users, setUsers]         = useState<AdminUser[]>([]);
+  const [loading, setLoading]     = useState(true);
+  const [creating, setCreating]   = useState(false);
+  const [form, setForm]           = useState({ fullName: "", username: "", phone: "", password: "PicBox@2026", role: "sender" });
+  const [formError, setFormError] = useState("");
+
+  const loadUsers = () => {
+    setLoading(true);
+    getAllUsers()
+      .then(setUsers)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { loadUsers(); }, []);
 
   const filtered = users.filter((u) => {
     const q = search.toLowerCase();
-    const matchSearch = u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q);
+    const matchSearch = u.fullName.toLowerCase().includes(q) || u.username.toLowerCase().includes(q);
     const matchRole = roleFilter === "all" || u.role === roleFilter;
     return matchSearch && matchRole;
   });
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Xác nhận xóa người dùng này?")) return;
+    try {
+      await deleteUser(id);
+      setUsers((prev) => prev.filter((u) => u.id !== id));
+    } catch (e: unknown) {
+      alert((e as Error).message);
+    }
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.username || !form.fullName) {
+      setFormError("Vui lòng điền đầy đủ thông tin");
+      return;
+    }
+    setCreating(true);
+    setFormError("");
+    try {
+      await apiRegister({
+        username: form.username,
+        password: form.password,
+        fullName: form.fullName,
+        phone: form.phone,
+      });
+      setModalOpen(false);
+      setForm({ fullName: "", username: "", phone: "", password: "PicBox@2026", role: "sender" });
+      loadUsers();
+    } catch (e: unknown) {
+      setFormError((e as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
 
   return (
     <AdminLayout>
@@ -66,6 +96,7 @@ export default function UsersPage() {
             <p className="text-[13px] text-slate-500 mt-0.5">Quản lý tài khoản và phân quyền</p>
           </div>
           <button
+            type="button"
             onClick={() => setModalOpen(true)}
             className="inline-flex items-center gap-2 h-9 px-4 rounded-xl gradient-brand text-white text-[13px] font-semibold shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 transition-all cursor-pointer"
           >
@@ -80,21 +111,15 @@ export default function UsersPage() {
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Tìm theo tên, email..."
+              placeholder="Tìm theo tên, username..."
               className="w-full h-9 rounded-xl bg-white/[0.04] border border-white/[0.08] pl-9 pr-4 text-[13px] text-slate-300 placeholder-slate-600 outline-none transition-all focus:border-indigo-500/40 focus:ring-1 focus:ring-indigo-500/20"
             />
           </div>
           <div className="flex gap-1.5 flex-wrap">
-            {[
-              { key: "all", label: "Tất cả" },
-              { key: "admin", label: "Admin" },
-              { key: "ops", label: "Ops" },
-              { key: "shipper", label: "Shipper" },
-              { key: "driver", label: "Driver" },
-              { key: "sender", label: "Sender" },
-            ].map((r) => (
+            {ROLE_TABS.map((r) => (
               <button
                 key={r.key}
+                type="button"
                 onClick={() => setRoleFilter(r.key)}
                 className={`px-3 py-1.5 rounded-lg text-[12px] font-medium transition-all cursor-pointer border ${
                   roleFilter === r.key
@@ -110,71 +135,72 @@ export default function UsersPage() {
 
         {/* Table */}
         <div className="rounded-2xl glass overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-white/[0.06]">
-                  {["Người dùng", "Điện thoại", "Vai trò", "Trạng thái", "Ngày tạo", ""].map((h) => (
-                    <th key={h} className="px-5 py-3.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">
-                      {h}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-white/[0.04]">
-                {filtered.map((user) => (
-                  <tr key={user.id} className="hover:bg-white/[0.02] transition-colors">
-                    <td className="px-5 py-3.5">
-                      <div className="flex items-center gap-3">
-                        <div className="h-9 w-9 rounded-xl gradient-brand flex items-center justify-center text-[12px] font-bold text-white shadow-md shadow-indigo-500/15">
-                          {user.name.charAt(0)}
-                        </div>
-                        <div>
-                          <p className="text-[13px] font-medium text-white">{user.name}</p>
-                          <p className="text-[11px] text-slate-500">{user.email}</p>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-5 py-3.5 text-[13px] text-slate-400">{user.phone}</td>
-                    <td className="px-5 py-3.5">
-                      <Badge variant={roleConfig[user.role].variant}>{roleConfig[user.role].label}</Badge>
-                    </td>
-                    <td className="px-5 py-3.5">
-                      <Badge variant={statusConfig[user.status].variant}>{statusConfig[user.status].label}</Badge>
-                    </td>
-                    <td className="px-5 py-3.5 text-[13px] text-slate-500">{user.created}</td>
-                    <td className="px-5 py-3.5">
-                      <div className="flex items-center gap-1">
-                        <button className="p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/[0.06] transition-all cursor-pointer">
-                          <Edit2 size={13} />
-                        </button>
-                        <button className="p-1.5 rounded-lg text-slate-500 hover:text-rose-400 hover:bg-rose-500/[0.06] transition-all cursor-pointer">
-                          <Trash2 size={13} />
-                        </button>
-                      </div>
-                    </td>
+          {loading ? (
+            <div className="flex items-center justify-center py-16">
+              <Loader size={20} className="text-indigo-400 animate-spin" />
+              <span className="ml-2 text-[13px] text-slate-500">Đang tải người dùng...</span>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-white/[0.06]">
+                    {["Người dùng", "Điện thoại", "Vai trò", ""].map((h) => (
+                      <th key={h} className="px-5 py-3.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                        {h}
+                      </th>
+                    ))}
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {/* Footer */}
+                </thead>
+                <tbody className="divide-y divide-white/[0.04]">
+                  {filtered.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-5 py-10 text-center text-[13px] text-slate-600">
+                        Không có người dùng nào
+                      </td>
+                    </tr>
+                  ) : filtered.map((user) => {
+                    const rc = ROLE_CONFIG[user.role] ?? ROLE_CONFIG.sender;
+                    return (
+                      <tr key={user.id} className="hover:bg-white/[0.02] transition-colors">
+                        <td className="px-5 py-3.5">
+                          <div className="flex items-center gap-3">
+                            <div className="h-9 w-9 rounded-xl gradient-brand flex items-center justify-center text-[12px] font-bold text-white shadow-md shadow-indigo-500/15">
+                              {(user.fullName || user.username).charAt(0).toUpperCase()}
+                            </div>
+                            <div>
+                              <p className="text-[13px] font-medium text-white">{user.fullName || user.username}</p>
+                              <p className="text-[11px] text-slate-500">{user.username}</p>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-5 py-3.5 text-[13px] text-slate-400">{user.phone || "—"}</td>
+                        <td className="px-5 py-3.5">
+                          <Badge variant={rc.variant}>{rc.label}</Badge>
+                        </td>
+                        <td className="px-5 py-3.5">
+                          <div className="flex items-center gap-1">
+                            <button
+                              type="button"
+                              title="Xóa người dùng"
+                              onClick={() => handleDelete(user.id)}
+                              className="p-1.5 rounded-lg text-slate-500 hover:text-rose-400 hover:bg-rose-500/[0.06] transition-all cursor-pointer"
+                            >
+                              <Trash2 size={13} />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
           <div className="flex items-center justify-between px-5 py-3 border-t border-white/[0.04]">
             <p className="text-[12px] text-slate-600">
               Hiển thị {filtered.length} / {users.length} người dùng
             </p>
-            <div className="flex items-center gap-1.5">
-              {[1, 2, 3].map((p) => (
-                <button
-                  key={p}
-                  className={`h-7 w-7 rounded-lg text-[12px] font-medium transition-all cursor-pointer ${
-                    p === 1 ? "bg-indigo-500/15 text-indigo-400" : "text-slate-500 hover:bg-white/[0.04]"
-                  }`}
-                >
-                  {p}
-                </button>
-              ))}
-            </div>
           </div>
         </div>
 
@@ -182,44 +208,43 @@ export default function UsersPage() {
         {modalOpen && (
           <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={() => setModalOpen(false)}>
             <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-            <div className="relative w-full max-w-md rounded-2xl border border-white/[0.08] bg-[#0c1225]/95 backdrop-blur-xl p-6 shadow-2xl animate-fadeIn" onClick={(e) => e.stopPropagation()}>
+            <div
+              className="relative w-full max-w-md rounded-2xl border border-white/[0.08] bg-[#0c1225]/95 backdrop-blur-xl p-6 shadow-2xl animate-fadeIn"
+              onClick={(e) => e.stopPropagation()}
+            >
               <div className="flex items-center justify-between mb-5">
                 <h2 className="text-[16px] font-semibold text-white">Thêm người dùng</h2>
-                <button onClick={() => setModalOpen(false)} className="p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/[0.06] transition-all cursor-pointer">
+                <button type="button" title="Đóng" onClick={() => setModalOpen(false)} className="p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/[0.06] transition-all cursor-pointer">
                   <X size={16} />
                 </button>
               </div>
-              <form className="space-y-3.5">
+              <form className="space-y-3.5" onSubmit={handleCreate}>
                 {[
-                  { label: "Họ và tên", placeholder: "Nguyễn Văn A", type: "text" },
-                  { label: "Email", placeholder: "user@picbox.vn", type: "email" },
-                  { label: "Số điện thoại", placeholder: "0901234567", type: "tel" },
+                  { key: "fullName",  label: "Họ và tên",      placeholder: "Nguyễn Văn A",    type: "text" },
+                  { key: "username",  label: "Username / Email", placeholder: "user@picbox.vn", type: "text" },
+                  { key: "phone",     label: "Số điện thoại",  placeholder: "0901234567",       type: "tel" },
+                  { key: "password",  label: "Mật khẩu",       placeholder: "••••••••",         type: "password" },
                 ].map((f) => (
-                  <div key={f.label} className="space-y-1.5">
+                  <div key={f.key} className="space-y-1.5">
                     <label className="text-[13px] font-medium text-slate-400">{f.label}</label>
                     <input
                       type={f.type}
                       placeholder={f.placeholder}
+                      value={form[f.key as keyof typeof form]}
+                      onChange={(e) => setForm((prev) => ({ ...prev, [f.key]: e.target.value }))}
                       className="w-full h-10 rounded-xl bg-white/[0.04] border border-white/[0.08] px-3.5 text-[13px] text-white placeholder-slate-600 outline-none focus:border-indigo-500/40 focus:ring-1 focus:ring-indigo-500/20"
                     />
                   </div>
                 ))}
-                <div className="space-y-1.5">
-                  <label className="text-[13px] font-medium text-slate-400">Vai trò</label>
-                  <select className="w-full h-10 rounded-xl bg-white/[0.04] border border-white/[0.08] px-3.5 text-[13px] text-white outline-none focus:border-indigo-500/40 cursor-pointer">
-                    <option value="sender">Sender</option>
-                    <option value="shipper">Shipper</option>
-                    <option value="driver">Driver</option>
-                    <option value="ops">Ops Manager</option>
-                    <option value="admin">Admin</option>
-                  </select>
-                </div>
+                {formError && (
+                  <p className="text-[12px] text-rose-400">{formError}</p>
+                )}
                 <div className="flex gap-3 pt-3">
                   <button type="button" onClick={() => setModalOpen(false)} className="flex-1 h-10 rounded-xl bg-white/[0.04] border border-white/[0.08] text-[13px] font-medium text-slate-400 hover:bg-white/[0.06] transition-all cursor-pointer">
                     Hủy
                   </button>
-                  <button type="submit" className="flex-1 h-10 rounded-xl gradient-brand text-white text-[13px] font-semibold shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 transition-all cursor-pointer">
-                    Tạo người dùng
+                  <button type="submit" disabled={creating} className="flex-1 h-10 rounded-xl gradient-brand text-white text-[13px] font-semibold shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 transition-all cursor-pointer disabled:opacity-60">
+                    {creating ? "Đang tạo..." : "Tạo người dùng"}
                   </button>
                 </div>
               </form>

--- a/apps/packages/utils/src/admin-api.ts
+++ b/apps/packages/utils/src/admin-api.ts
@@ -1,0 +1,258 @@
+import { apiClient } from "./api-client";
+import { toFrontendStatus } from "./order-api";
+import type { OrderPage } from "./order-api";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AdminUser {
+  id: string;
+  username: string;
+  fullName: string;
+  phone: string;
+  role: string;
+}
+
+export interface AdminHub {
+  id: string;
+  name: string;
+  type: "hub" | "branch";
+  address: string;
+  province: string;
+  contactPhone: string;
+  active: boolean;
+  hubName?: string;
+  maxCapacity?: number;
+}
+
+export interface AdminOrder {
+  id: string;
+  trackingCode: string;
+  senderName: string;
+  senderPhone: string;
+  receiverName: string;
+  receiverPhone: string;
+  originBranchName: string;
+  destBranchName: string;
+  receiverAddress: string;
+  weight: number;
+  fee: number;
+  codAmount: number;
+  status: string;
+  backendStatus: string;
+  shipperId?: string;
+  note?: string;
+  createdAt: string;
+}
+
+// ─── Internal adapters ────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function adaptAdminOrder(o: any): AdminOrder {
+  return {
+    id: o.id,
+    trackingCode: o.trackingCode,
+    senderName: o.senderName,
+    senderPhone: o.senderPhone,
+    receiverName: o.receiverName,
+    receiverPhone: o.receiverPhone,
+    originBranchName: o.originBranchName,
+    destBranchName: o.destBranchName,
+    receiverAddress: o.receiverAddress,
+    weight: o.weight,
+    fee: o.fee,
+    codAmount: o.codAmount ?? 0,
+    status: toFrontendStatus(o.status),
+    backendStatus: o.status,
+    shipperId: o.shipperId,
+    note: o.note,
+    createdAt: o.createdAt,
+  };
+}
+
+// ─── Orders ───────────────────────────────────────────────────────────────────
+
+const ADMIN_STATUSES = [
+  "PENDING",
+  "CONFIRMED",
+  "PICKED_UP",
+  "OUT_FOR_DELIVERY",
+  "DELIVERED",
+  "DELIVERY_FAILED",
+  "CANCELLED",
+];
+
+export async function getAllAdminOrders(): Promise<AdminOrder[]> {
+  const results = await Promise.allSettled(
+    ADMIN_STATUSES.map((s) =>
+      apiClient.get(`/order/orders/status/${s}`, { params: { page: 0, size: 50 } })
+    )
+  );
+
+  const orders: AdminOrder[] = [];
+  for (const r of results) {
+    if (r.status === "fulfilled") {
+      const content = r.value.data?.result?.content ?? [];
+      orders.push(...content.map(adaptAdminOrder));
+    }
+  }
+  // Sort by createdAt desc
+  orders.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  return orders;
+}
+
+export async function countOrdersByStatus(status: string): Promise<number> {
+  try {
+    const { data } = await apiClient.get(`/order/orders/status/${status}`, {
+      params: { page: 0, size: 1 },
+    });
+    return data?.result?.totalElements ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function updateOrderStatus(
+  orderId: string,
+  status: string,
+  note?: string
+): Promise<void> {
+  const { data } = await apiClient.put(`/order/orders/${orderId}/status`, {
+    status,
+    note,
+  });
+  if (data.code !== 0 && data.code !== 1000) {
+    throw new Error(data.message || "Cập nhật trạng thái thất bại");
+  }
+}
+
+// ─── Users ────────────────────────────────────────────────────────────────────
+
+export async function getAllUsers(): Promise<AdminUser[]> {
+  const [usersRes, profilesRes] = await Promise.allSettled([
+    apiClient.get("/identity/users/getAllUser"),
+    apiClient.get("/profile/profiles/GetAllProfile"),
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const users: any[] =
+    usersRes.status === "fulfilled" ? (usersRes.value.data?.result ?? []) : [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const profiles: any[] =
+    profilesRes.status === "fulfilled"
+      ? (profilesRes.value.data?.result ?? [])
+      : [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const profileMap = new Map<string, any>(profiles.map((p) => [p.userId, p]));
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return users.map((u: any) => {
+    const profile = profileMap.get(u.id);
+    const roleName: string =
+      (u.roles as { name: string }[])?.[0]?.name?.toLowerCase() ?? "sender";
+    return {
+      id: u.id,
+      username: u.username,
+      fullName: profile?.fullName || u.username,
+      phone: profile?.phoneNumber || "",
+      role: roleName,
+    };
+  });
+}
+
+export async function countUsersByRole(role: string): Promise<number> {
+  try {
+    const { data } = await apiClient.get(
+      `/identity/users/countUserWithRole/${role}`
+    );
+    return (data?.result as number) ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+  const { data } = await apiClient.delete(
+    `/identity/users/deleteUser/${userId}`
+  );
+  if (data.code !== 0 && data.code !== 1000) {
+    throw new Error(data.message || "Xóa người dùng thất bại");
+  }
+}
+
+// ─── Hubs & Branches ──────────────────────────────────────────────────────────
+
+export async function getAllHubsAndBranches(): Promise<AdminHub[]> {
+  const [hubsRes, branchesRes] = await Promise.allSettled([
+    apiClient.get("/hub/hubs"),
+    apiClient.get("/hub/branches"),
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const hubs: AdminHub[] =
+    hubsRes.status === "fulfilled"
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (hubsRes.value.data?.result ?? []).map((h: any) => ({
+          id: h.id,
+          name: h.name,
+          type: "hub" as const,
+          address: h.address || "",
+          province: h.province || h.areaName || "",
+          contactPhone: h.contactPhone || "",
+          active: h.active ?? true,
+        }))
+      : [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const branches: AdminHub[] =
+    branchesRes.status === "fulfilled"
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (branchesRes.value.data?.result ?? []).map((b: any) => ({
+          id: b.id,
+          name: b.name,
+          type: "branch" as const,
+          address: [b.address, b.district, b.ward].filter(Boolean).join(", "),
+          province: b.province || "",
+          contactPhone: b.contactPhone || "",
+          active: b.active ?? true,
+          hubName: b.hubName,
+          maxCapacity: b.maxCapacity,
+        }))
+      : [];
+
+  return [...hubs, ...branches];
+}
+
+// ─── Dashboard stats ──────────────────────────────────────────────────────────
+
+export interface DashboardStats {
+  totalOrders: number;
+  deliveringOrders: number;
+  deliveredOrders: number;
+  failedOrders: number;
+  totalUsers: number;
+  totalShippers: number;
+}
+
+export async function getDashboardStats(): Promise<DashboardStats> {
+  const [pending, delivering, delivered, failed, totalUsers, totalShippers] =
+    await Promise.all([
+      countOrdersByStatus("PENDING"),
+      countOrdersByStatus("OUT_FOR_DELIVERY"),
+      countOrdersByStatus("DELIVERED"),
+      countOrdersByStatus("DELIVERY_FAILED"),
+      countUsersByRole("SENDER").catch(() => 0),
+      countUsersByRole("SHIPPER").catch(() => 0),
+    ]);
+
+  return {
+    totalOrders: pending + delivering + delivered + failed,
+    deliveringOrders: delivering,
+    deliveredOrders: delivered,
+    failedOrders: failed,
+    totalUsers,
+    totalShippers,
+  };
+}

--- a/apps/packages/utils/src/index.ts
+++ b/apps/packages/utils/src/index.ts
@@ -9,3 +9,10 @@ export {
   BRANCH_LIST,
 } from "./order-api";
 export type { CreateOrderParams, OrderPage, OrderHistoryEvent, Branch } from "./order-api";
+export {
+  getAllAdminOrders, countOrdersByStatus, updateOrderStatus,
+  getAllUsers, countUsersByRole, deleteUser,
+  getAllHubsAndBranches,
+  getDashboardStats,
+} from "./admin-api";
+export type { AdminUser, AdminHub, AdminOrder, DashboardStats } from "./admin-api";


### PR DESCRIPTION
- Thêm admin-api.ts với các hàm gọi API cho đơn hàng, người dùng, hub, dashboard
- Thay thế mock data bằng dữ liệu thật ở các trang orders/users/hubs/dashboard
- Kết hợp dữ liệu từ identity-service và profile-service để hiển thị người dùng
- Lấy danh sách hub và chi nhánh từ hub-and-branch-service